### PR TITLE
Fixing typescript--forward-expression for multiline indented string

### DIFF
--- a/typescript-mode-general-tests.el
+++ b/typescript-mode-general-tests.el
@@ -183,6 +183,43 @@ a severity set to WARNING, no rule name."
     ;; completing and not locking up is test-success!
     ))
 
+(ert-deftest typescript--forward-expression-on-multiline-indented-string ()
+  "Testcase for https://github.com/emacs-typescript/typescript.el/issues/105"
+
+  (with-temp-buffer
+    (typescript-mode)
+
+    (insert
+"fetch('http://localhost:8529/_db/_system/land', {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+    Accept: 'application/json',
+  },
+  body: JSON.stringify({
+    query: `{
+      query GetElement {
+        element(id: \"0000\") {
+          collection
+          id
+          name
+          description
+        }
+      }
+    }`,
+  }),
+})
+  .then(r => r.json())
+  .then(data => console.log('data returned:', data));")
+
+    (goto-char (point-min))
+    (typescript--forward-expression)
+    ;; completing and not locking up is test-success!
+    ;; Should there be a time-out? Or it is handled by external tool?
+
+    ;; Check that `typescript--forward-expression' jumped to the right position.
+    (should (= 434 (point)))))
+
 (defun test-re-search (searchee contents offset)
   (with-temp-buffer
     (typescript-mode)

--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -989,13 +989,13 @@ one at the end of the line with \"let a\"."
 This function doesn't move over expressions continued across
 lines."
   (loop
-   ;; non-continued case; simplistic, but good enough?
-   do (loop until (or (eolp)
-                      (progn
-                        (forward-comment most-positive-fixnum)
-                        (memq (char-after) '(?\, ?\; ?\] ?\) ?\}))))
-            do (forward-sexp))
-
+   do (progn
+        (forward-comment most-positive-fixnum)
+        (loop until (or (eolp)
+                        (progn
+                          (forward-comment most-positive-fixnum)
+                          (memq (char-after) '(?\, ?\; ?\] ?\) ?\}))))
+              do (forward-sexp)))
    while (and (eq (char-after) ?\n)
               (save-excursion
                 (forward-char)


### PR DESCRIPTION
See https://github.com/emacs-typescript/typescript.el/issues/105 for details.

This fix includes typescript--forward-expression-on-multiline-indented-string
ert test case.