### PR TITLE
Enable more colors

### DIFF
--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -300,7 +300,10 @@ Match group 1 is MUMBLE.")
 (defconst typescript--builtin-re
   (typescript--regexp-opt-symbol
    '("console"))
-  "Regular expression matching builtin stuff.")
+  "Regular expression matching builtins.")
+
+(defconst typescript--function-call-re "\\(\\w+\\)\s*("
+  "Regular expression matching function calls.")
 
 (defconst typescript--font-lock-keywords-1
   (list
@@ -619,7 +622,7 @@ Match group 1 is MUMBLE.")
 
 (defface typescript-access-modifier-face
   '((t (:inherit font-lock-keyword-face)))
-  "Face used to highlight 'this' keyword."
+  "Face used to highlight access modifiers."
   :group 'typescript)
 
 ;;; User Customization
@@ -1853,9 +1856,9 @@ and searches for the next token to be highlighted."
      (1 font-lock-type-face))
 
     ;; variable declarations
-    ;; ,(list
-    ;;   (concat "\\_<\\(const\\|var\\|let\\)\\_>\\|" typescript--basic-type-re)
-    ;;   (list #'typescript--variable-decl-matcher nil nil nil))
+    ,(list
+      (concat "\\_<\\(const\\|var\\|let\\)\\_>\\|" typescript--basic-type-re)
+      (list #'typescript--variable-decl-matcher nil nil nil))
 
     ;; class instantiation
     ,(list
@@ -1996,7 +1999,6 @@ This performs fontification according to `typescript--class-styles'."
         return t
         else do (goto-char orig-end)))
 
-(defconst typescript--function-call-re "\\(\\w+\\)\s*(")
 (defconst typescript--font-lock-keywords-4
   (append typescript--font-lock-keywords-3
     (list

--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -305,7 +305,7 @@ Match group 1 is MUMBLE.")
    '("console"))
   "Regular expression matching builtins.")
 
-(defconst typescript--function-call-re "\\(\\w+\\)\s*("
+(defconst typescript--function-call-re "\\(\\w+\\)\\(<.+>\\)?\s*("
   "Regular expression matching function calls.")
 
 (defconst typescript--font-lock-keywords-1

--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -1966,10 +1966,17 @@ This performs fontification according to `typescript--class-styles'."
         return t
         else do (goto-char orig-end)))
 
+(defconst typescript--function-call-re "\\(\\w+\\)\s*(")
+(defconst typescript--font-lock-keywords-4
+  (append typescript--font-lock-keywords-3
+          (list (list typescript--function-call-re 1 font-lock-function-name-face)))
+  "Level four stuff.")
+
 (defconst typescript--font-lock-keywords
-  '(typescript--font-lock-keywords-3 typescript--font-lock-keywords-1
+  '(typescript--font-lock-keywords-4 typescript--font-lock-keywords-1
                                    typescript--font-lock-keywords-2
-                                   typescript--font-lock-keywords-3)
+                                   typescript--font-lock-keywords-3
+                                   typescript--font-lock-keywords-4)
   "Font lock keywords for `typescript-mode'.  See `font-lock-keywords'.")
 
 ;;; Propertize

--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -284,6 +284,10 @@ Match group 1 is MUMBLE.")
    '("any" "bool" "boolean" "bigint" "never" "number" "string" "unknown" "void"))
   "Regular expression matching any predefined type in typescript.")
 
+(defconst typescript--type-hint-re
+   (concat "\\:\\s-+" "\\(" typescript--name-re "\\)")
+   "Regular expression matching type hints that follow the `:' operator.")
+
 (defconst typescript--constant-re
   (typescript--regexp-opt-symbol '("false" "null" "undefined"
                                  "Infinity" "NaN"
@@ -306,7 +310,8 @@ Match group 1 is MUMBLE.")
                       (list 1 'font-lock-keyword-face))
                 (cons "\\_<yield\\(\\*\\|\\_>\\)" 'font-lock-keyword-face)
                 (cons typescript--basic-type-re font-lock-builtin-face)
-                (cons typescript--constant-re font-lock-type-face)))
+                (list typescript--type-hint-re 1 font-lock-type-face)
+                (cons typescript--constant-re font-lock-variable-name-face)))
   "Level two font lock keywords for `typescript-mode'.")
 
 ;; typescript--pitem is the basic building block of the lexical

--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -270,19 +270,22 @@ Match group 1 is MUMBLE.")
   (typescript--regexp-opt-symbol
    '("abstract" "any" "as" "async" "await" "boolean" "bigint" "break" "case" "catch" "class" "const"
      "constructor" "continue" "declare" "default" "delete" "do" "else"
-     "enum" "export" "extends" "extern" "finally" "for"
-     "function" "from" "get" "goto" "if" "implements" "import" "in" "instanceof"
-     "interface" "keyof" "let" "module" "namespace" "new" "of"
-     "private" "protected" "public" "readonly" "return" "set" "static"
-     "super" "switch" "throw" "true"
-     "try" "type" "typeof" "unknown" "var"
-     "while"))                  ; yield is handled separately
+     "enum" "export" "extern" "finally" "for" "function" "from" "get"
+     "goto" "if" "implements" "import" "in" "instanceof" "interface" "keyof"
+     "let" "module" "namespace" "new" "of" "return" "set" "super" "switch"
+     "throw" "true" "try" "type" "typeof" "unknown" "var"
+     "while")) ; yield is handled separately
   "Regexp matching any typescript keyword.")
 
 (defconst typescript--basic-type-re
   (typescript--regexp-opt-symbol
    '("any" "bool" "boolean" "bigint" "never" "number" "string" "unknown" "void"))
   "Regular expression matching any predefined type in typescript.")
+
+(defconst typescript--access-modifier-re
+  (typescript--regexp-opt-symbol
+   '("private" "protected" "public" "readonly" "static" "extends" "implements"))
+  "Regular expression matching access modifiers.")
 
 (defconst typescript--type-hint-re
    (concat "\\:\\s-+" "\\(" typescript--name-re "\\)")
@@ -292,8 +295,12 @@ Match group 1 is MUMBLE.")
   (typescript--regexp-opt-symbol '("false" "null" "undefined"
                                  "Infinity" "NaN"
                                  "true" "arguments"))
-  "Regular expression matching any future reserved words in typescript.")
+  "Regular expression matching constant values.")
 
+(defconst typescript--builtin-re
+  (typescript--regexp-opt-symbol
+   '("console"))
+  "Regular expression matching builtin stuff.")
 
 (defconst typescript--font-lock-keywords-1
   (list
@@ -309,7 +316,9 @@ Match group 1 is MUMBLE.")
                       "\\s-+\\(each\\)\\_>" nil nil
                       (list 1 'font-lock-keyword-face))
                 (cons "\\_<yield\\(\\*\\|\\_>\\)" 'font-lock-keyword-face)
+                (cons typescript--access-modifier-re ''typescript-access-modifier-face)
                 (cons typescript--basic-type-re font-lock-builtin-face)
+                (cons typescript--builtin-re font-lock-type-face)
                 (list typescript--type-hint-re 1 font-lock-type-face)
                 (cons typescript--constant-re font-lock-variable-name-face)))
   "Level two font lock keywords for `typescript-mode'.")
@@ -604,6 +613,11 @@ Match group 1 is MUMBLE.")
   :group 'typescript)
 
 (defface typescript-this-face
+  '((t (:inherit font-lock-keyword-face)))
+  "Face used to highlight 'this' keyword."
+  :group 'typescript)
+
+(defface typescript-access-modifier-face
   '((t (:inherit font-lock-keyword-face)))
   "Face used to highlight 'this' keyword."
   :group 'typescript)

--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -297,8 +297,8 @@ Match group 1 is MUMBLE.")
 (defconst typescript--constant-re
   (typescript--regexp-opt-symbol '("false" "null" "undefined"
                                  "Infinity" "NaN"
-                                 "true" "arguments"))
-  "Regular expression matching builtin values.")
+                                 "true" "arguments" "this"))
+  "Regular expression matching any future reserved words in typescript.")
 
 (defconst typescript--builtin-re
   (typescript--regexp-opt-symbol

--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -283,10 +283,6 @@ Match group 1 is MUMBLE.")
    '("private" "protected" "public" "readonly" "static" "extends" "implements"))
   "Regular expression matching access modifiers.")
 
-(defconst typescript--type-hint-re
-   (concat "\\:\\s-+" "\\(" typescript--name-re "\\)")
-   "Regular expression matching type hints that follow the `:' operator.")
-
 (defconst typescript--generic-type-re
   "<\\(.*\\)>"
    "Regular expression matching generic types.")
@@ -2017,11 +2013,9 @@ This performs fontification according to `typescript--class-styles'."
     ("\\(this\\)\\."
      (1 'typescript-this-face))
 
-
     (,typescript--access-modifier-re (1 'typescript-access-modifier-face))
     (,typescript--basic-type-re (1 'typescript-primitive-face))
     (,typescript--constant-re (1 font-lock-variable-name-face))
-
 
     ;; highlights that append to previous levels
     ;;
@@ -2032,7 +2026,6 @@ This performs fontification according to `typescript--class-styles'."
     (,typescript--function-call-re (1 font-lock-function-name-face))
     (,typescript--builtin-re (1 font-lock-type-face))
 
-    ;; (,typescript--type-hint-re (1 font-lock-type-face))
     (,typescript--generic-type-re (1 font-lock-type-face))
     (,typescript--generic-type-extended-re (1 font-lock-type-face))
 

--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -287,6 +287,17 @@ Match group 1 is MUMBLE.")
    (concat "\\:\\s-+" "\\(" typescript--name-re "\\)")
    "Regular expression matching type hints that follow the `:' operator.")
 
+(defconst typescript--generic-type-re
+  "<\\(.*\\)>"
+   "Regular expression matching generic types.")
+
+(defconst typescript--generic-type-extended-re
+  (concat "<\\(.*\\)extends\\(.*\\)>")
+   "Regular expression matching generic types with extension.")
+
+(defconst typescript--decorator-re
+  (concat "\\(@" typescript--name-re "\\)"))
+
 (defconst typescript--constant-re
   (typescript--regexp-opt-symbol '("false" "null" "undefined"
                                  "Infinity" "NaN"
@@ -2010,14 +2021,18 @@ This performs fontification according to `typescript--class-styles'."
     (,typescript--basic-type-re (1 'typescript-primitive-face))
     (,typescript--constant-re (1 font-lock-variable-name-face))
 
+
     ;; highlights that append to previous levels
     ;;
     ,@typescript--font-lock-keywords-2
     ,@typescript--font-lock-keywords-3
 
+    (,typescript--decorator-re (1 font-lock-function-name-face))
     (,typescript--function-call-re (1 font-lock-function-name-face))
     (,typescript--builtin-re (1 font-lock-type-face))
     (,typescript--type-hint-re (1 font-lock-type-face))
+    (,typescript--generic-type-re (1 font-lock-type-face))
+    (,typescript--generic-type-extended-re (1 font-lock-type-face))
 
     ;; arrow function
     ("\\(=>\\)"

--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -264,12 +264,12 @@ Match group 1 is MUMBLE.")
   (typescript--regexp-opt-symbol
    '("abstract" "any" "as" "async" "await" "boolean" "bigint" "break" "case" "catch" "class" "const"
      "constructor" "continue" "declare" "default" "delete" "do" "else"
-     "enum" "export" "extends" "extern" "false" "finally" "for"
+     "enum" "export" "extends" "extern" "finally" "for"
      "function" "from" "get" "goto" "if" "implements" "import" "in" "instanceof"
-     "interface" "keyof" "let" "module" "namespace" "never" "new" "null" "number" "object" "of"
-     "private" "protected" "public" "readonly" "return" "set" "static" "string"
+     "interface" "keyof" "let" "module" "namespace" "new" "of"
+     "private" "protected" "public" "readonly" "return" "set" "static"
      "super" "switch"  "this" "throw" "true"
-     "try" "type" "typeof" "unknown" "var" "void"
+     "try" "type" "typeof" "unknown" "var"
      "while"))                  ; yield is handled separately
   "Regexp matching any typescript keyword.")
 
@@ -281,7 +281,7 @@ Match group 1 is MUMBLE.")
 (defconst typescript--constant-re
   (typescript--regexp-opt-symbol '("false" "null" "undefined"
                                  "Infinity" "NaN"
-                                 "true" "arguments" "this"))
+                                 "true" "arguments"))
   "Regular expression matching any future reserved words in typescript.")
 
 
@@ -299,8 +299,8 @@ Match group 1 is MUMBLE.")
                       "\\s-+\\(each\\)\\_>" nil nil
                       (list 1 'font-lock-keyword-face))
                 (cons "\\_<yield\\(\\*\\|\\_>\\)" 'font-lock-keyword-face)
-                (cons typescript--basic-type-re font-lock-type-face)
-                (cons typescript--constant-re font-lock-constant-face)))
+                (cons typescript--basic-type-re font-lock-builtin-face)
+                (cons typescript--constant-re font-lock-type-face)))
   "Level two font lock keywords for `typescript-mode'.")
 
 ;; typescript--pitem is the basic building block of the lexical

--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -315,11 +315,8 @@ Match group 1 is MUMBLE.")
                       "\\s-+\\(each\\)\\_>" nil nil
                       (list 1 'font-lock-keyword-face))
                 (cons "\\_<yield\\(\\*\\|\\_>\\)" 'font-lock-keyword-face)
-                (cons typescript--access-modifier-re ''typescript-access-modifier-face)
-                (cons typescript--basic-type-re font-lock-builtin-face)
-                (cons typescript--builtin-re font-lock-type-face)
-                (list typescript--type-hint-re 1 font-lock-type-face)
-                (cons typescript--constant-re font-lock-variable-name-face)))
+                (cons typescript--basic-type-re font-lock-type-face)
+                (cons typescript--constant-re font-lock-constant-face)))
   "Level two font lock keywords for `typescript-mode'.")
 
 ;; typescript--pitem is the basic building block of the lexical
@@ -611,14 +608,19 @@ Match group 1 is MUMBLE.")
   "Face used to highlight tag values in jsdoc comments."
   :group 'typescript)
 
+(defface typescript-access-modifier-face
+  '((t (:inherit font-lock-keyword-face)))
+  "Face used to highlight access modifiers."
+  :group 'typescript)
+
 (defface typescript-this-face
   '((t (:inherit font-lock-keyword-face)))
   "Face used to highlight 'this' keyword."
   :group 'typescript)
 
-(defface typescript-access-modifier-face
+(defface typescript-primitive-face
   '((t (:inherit font-lock-keyword-face)))
-  "Face used to highlight access modifiers."
+  "Face used to highlight builtin types."
   :group 'typescript)
 
 ;;; User Customization
@@ -1997,14 +1999,25 @@ This performs fontification according to `typescript--class-styles'."
 
 (defconst typescript--font-lock-keywords-4
   `(
+    ;; highlights that override previous levels
+    ;;
+
     ;; special highlight for `this' keyword
     ("\\(this\\)\\."
      (1 'typescript-this-face))
 
+    (,typescript--access-modifier-re (1 'typescript-access-modifier-face))
+    (,typescript--basic-type-re (1 'typescript-primitive-face))
+    (,typescript--constant-re (1 font-lock-variable-name-face))
+
+    ;; highlights that append to previous levels
+    ;;
     ,@typescript--font-lock-keywords-2
     ,@typescript--font-lock-keywords-3
 
     (,typescript--function-call-re (1 font-lock-function-name-face))
+    (,typescript--builtin-re (1 font-lock-type-face))
+    (,typescript--type-hint-re (1 font-lock-type-face))
 
     ;; arrow function
     ("\\(=>\\)"

--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -77,12 +77,6 @@
   (concat typescript--name-re "\\(?:\\." typescript--name-re "\\)*")
   "Regexp matching a dot-separated sequence of typescript names.")
 
-(defconst typescript--this-re "\\(this\\)\\_>"
-  "Regexp matching the `this' keyword.")
-
-(defconst typescript--arrow-re "=>"
-  "Regexp matching the arrow operator.")
-
 (defconst typescript--plain-method-re
   (concat "^\\s-*?\\(" typescript--dotted-name-re "\\)\\.prototype"
           "\\.\\(" typescript--name-re "\\)\\s-*?=\\s-*?\\(function\\)\\_>")
@@ -2002,12 +1996,21 @@ This performs fontification according to `typescript--class-styles'."
         else do (goto-char orig-end)))
 
 (defconst typescript--font-lock-keywords-4
-  (append typescript--font-lock-keywords-3
-    (list
-      (list typescript--function-call-re 1 font-lock-function-name-face)
-      (cons typescript--this-re ''typescript-this-face)
-      (cons typescript--arrow-re font-lock-keyword-face)))
-  "Level four stuff.")
+  `(
+    ;; special highlight for `this' keyword
+    ("\\(this\\)\\."
+     (1 'typescript-this-face))
+
+    ,@typescript--font-lock-keywords-2
+    ,@typescript--font-lock-keywords-3
+
+    (,typescript--function-call-re (1 font-lock-function-name-face))
+
+    ;; arrow function
+    ("\\(=>\\)"
+     (1 font-lock-keyword-face))
+    )
+  "Level four font lock for `typescript-mode'.")
 
 (defconst typescript--font-lock-keywords
   '(typescript--font-lock-keywords-4 typescript--font-lock-keywords-1

--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -283,6 +283,36 @@ Match group 1 is MUMBLE.")
    '("private" "protected" "public" "readonly" "static" "extends" "implements"))
   "Regular expression matching access modifiers.")
 
+(defconst ng2-ts-type-name-re
+  (concat "\\_<[A-Z_$]\\(?:\\s_\\|\\sw\\)*\\_>"))
+
+(defconst ng2-ts-name-re
+  (concat "\\_<[A-Za-z_$]\\(?:\\s_\\|\\sw\\)*\\_>"))
+
+(defconst ng2-ts-type-re
+  (concat
+   "\\(?:\\(?:" typescript--keyword-re "\\)\\|"
+   "\\(?:\\(?:" ng2-ts-type-name-re "\\|" ng2-ts-name-re "\\.\\)*"
+   "\\(" ng2-ts-type-name-re "\\)" ; Type name
+   "\\(?:\\[\\(" ng2-ts-type-name-re "\\)\\]\\)?\\)\\)")) ; Type subscript
+
+(defconst ng2-ts-type-annotation-re
+  (concat ":\\s-*" ng2-ts-type-re "\\s-*"))
+
+(defconst ng2-ts-fn-search-re
+  (concat
+   "\\(%s\\)" ; Function name
+   "\\(?:<.*?>\\)?" ; Generic argument
+   "([^)]*)\\s-*" ; Argument list
+   "\\(?::\\s-*" ng2-ts-type-re "\\)?"; Return type
+   "\\(?:<.*?>\\)?\\s-*{"))
+
+(defconst ng2-ts-name-re
+  (concat "\\_<[A-Za-z_$]\\(?:\\s_\\|\\sw\\)*\\_>"))
+
+(defconst ng2-ts-fn-re
+  (format ng2-ts-fn-search-re ng2-ts-name-re))
+
 (defconst typescript--type-hint-re
    (concat "\\:\\s-+" "\\(" typescript--name-re "\\)")
    "Regular expression matching type hints that follow the `:' operator.")
@@ -2017,6 +2047,7 @@ This performs fontification according to `typescript--class-styles'."
     ("\\(this\\)\\."
      (1 'typescript-this-face))
 
+
     (,typescript--access-modifier-re (1 'typescript-access-modifier-face))
     (,typescript--basic-type-re (1 'typescript-primitive-face))
     (,typescript--constant-re (1 font-lock-variable-name-face))
@@ -2027,10 +2058,12 @@ This performs fontification according to `typescript--class-styles'."
     ,@typescript--font-lock-keywords-2
     ,@typescript--font-lock-keywords-3
 
+    (,ng2-ts-fn-re (1 font-lock-type-face))
+    (,ng2-ts-type-annotation-re (2 font-lock-type-face))
     (,typescript--decorator-re (1 font-lock-function-name-face))
     (,typescript--function-call-re (1 font-lock-function-name-face))
     (,typescript--builtin-re (1 font-lock-type-face))
-    (,typescript--type-hint-re (1 font-lock-type-face))
+    ;; (,typescript--type-hint-re (1 font-lock-type-face))
     (,typescript--generic-type-re (1 font-lock-type-face))
     (,typescript--generic-type-extended-re (1 font-lock-type-face))
 

--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -77,6 +77,12 @@
   (concat typescript--name-re "\\(?:\\." typescript--name-re "\\)*")
   "Regexp matching a dot-separated sequence of typescript names.")
 
+(defconst typescript--this-re "\\(this\\)\\_>"
+  "Regexp matching the `this' keyword.")
+
+(defconst typescript--arrow-re "=>"
+  "Regexp matching the arrow operator.")
+
 (defconst typescript--plain-method-re
   (concat "^\\s-*?\\(" typescript--dotted-name-re "\\)\\.prototype"
           "\\.\\(" typescript--name-re "\\)\\s-*?=\\s-*?\\(function\\)\\_>")
@@ -268,7 +274,7 @@ Match group 1 is MUMBLE.")
      "function" "from" "get" "goto" "if" "implements" "import" "in" "instanceof"
      "interface" "keyof" "let" "module" "namespace" "new" "of"
      "private" "protected" "public" "readonly" "return" "set" "static"
-     "super" "switch"  "this" "throw" "true"
+     "super" "switch" "throw" "true"
      "try" "type" "typeof" "unknown" "var"
      "while"))                  ; yield is handled separately
   "Regexp matching any typescript keyword.")
@@ -590,6 +596,11 @@ Match group 1 is MUMBLE.")
 (defface typescript-jsdoc-value
   '((t :foreground "gold4"))
   "Face used to highlight tag values in jsdoc comments."
+  :group 'typescript)
+
+(defface typescript-this-face
+  '((t (:inherit font-lock-keyword-face)))
+  "Face used to highlight 'this' keyword."
   :group 'typescript)
 
 ;;; User Customization
@@ -1969,7 +1980,10 @@ This performs fontification according to `typescript--class-styles'."
 (defconst typescript--function-call-re "\\(\\w+\\)\s*(")
 (defconst typescript--font-lock-keywords-4
   (append typescript--font-lock-keywords-3
-          (list (list typescript--function-call-re 1 font-lock-function-name-face)))
+    (list
+      (list typescript--function-call-re 1 font-lock-function-name-face)
+      (cons typescript--this-re ''typescript-this-face)
+      (cons typescript--arrow-re font-lock-keyword-face)))
   "Level four stuff.")
 
 (defconst typescript--font-lock-keywords

--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -2015,7 +2015,6 @@ This performs fontification according to `typescript--class-styles'."
 
     (,typescript--access-modifier-re (1 'typescript-access-modifier-face))
     (,typescript--basic-type-re (1 'typescript-primitive-face))
-    (,typescript--constant-re (1 font-lock-variable-name-face))
 
     ;; highlights that append to previous levels
     ;;

--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -1851,7 +1851,7 @@ and searches for the next token to be highlighted."
     ;; formal parameters
     ,(list
       (concat
-       "\\_<function\\_>\\(\\s-+" typescript--name-re "\\)?\\s-*(\\s-*"
+       "\\_<function\\_>\\|=\\(\\s-+" typescript--name-re "\\)?\\s-*(\\s-*"
        typescript--name-start-re)
       (list (concat "\\(" typescript--name-re "\\)\\(\\s-*).*\\)?")
             '(backward-char)

--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -283,36 +283,6 @@ Match group 1 is MUMBLE.")
    '("private" "protected" "public" "readonly" "static" "extends" "implements"))
   "Regular expression matching access modifiers.")
 
-(defconst ng2-ts-type-name-re
-  (concat "\\_<[A-Z_$]\\(?:\\s_\\|\\sw\\)*\\_>"))
-
-(defconst ng2-ts-name-re
-  (concat "\\_<[A-Za-z_$]\\(?:\\s_\\|\\sw\\)*\\_>"))
-
-(defconst ng2-ts-type-re
-  (concat
-   "\\(?:\\(?:" typescript--keyword-re "\\)\\|"
-   "\\(?:\\(?:" ng2-ts-type-name-re "\\|" ng2-ts-name-re "\\.\\)*"
-   "\\(" ng2-ts-type-name-re "\\)" ; Type name
-   "\\(?:\\[\\(" ng2-ts-type-name-re "\\)\\]\\)?\\)\\)")) ; Type subscript
-
-(defconst ng2-ts-type-annotation-re
-  (concat ":\\s-*" ng2-ts-type-re "\\s-*"))
-
-(defconst ng2-ts-fn-search-re
-  (concat
-   "\\(%s\\)" ; Function name
-   "\\(?:<.*?>\\)?" ; Generic argument
-   "([^)]*)\\s-*" ; Argument list
-   "\\(?::\\s-*" ng2-ts-type-re "\\)?"; Return type
-   "\\(?:<.*?>\\)?\\s-*{"))
-
-(defconst ng2-ts-name-re
-  (concat "\\_<[A-Za-z_$]\\(?:\\s_\\|\\sw\\)*\\_>"))
-
-(defconst ng2-ts-fn-re
-  (format ng2-ts-fn-search-re ng2-ts-name-re))
-
 (defconst typescript--type-hint-re
    (concat "\\:\\s-+" "\\(" typescript--name-re "\\)")
    "Regular expression matching type hints that follow the `:' operator.")
@@ -2058,11 +2028,10 @@ This performs fontification according to `typescript--class-styles'."
     ,@typescript--font-lock-keywords-2
     ,@typescript--font-lock-keywords-3
 
-    (,ng2-ts-fn-re (1 font-lock-type-face))
-    (,ng2-ts-type-annotation-re (2 font-lock-type-face))
     (,typescript--decorator-re (1 font-lock-function-name-face))
     (,typescript--function-call-re (1 font-lock-function-name-face))
     (,typescript--builtin-re (1 font-lock-type-face))
+
     ;; (,typescript--type-hint-re (1 font-lock-type-face))
     (,typescript--generic-type-re (1 font-lock-type-face))
     (,typescript--generic-type-extended-re (1 font-lock-type-face))

--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -1878,7 +1878,7 @@ and searches for the next token to be highlighted."
     ;; formal parameters
     ,(list
       (concat
-       "\\_<function\\_>\\|=\\(\\s-+" typescript--name-re "\\)?\\s-*(\\s-*"
+       "\\_<function\\_>\\(\\s-+" typescript--name-re "\\)?\\s-*(\\s-*"
        typescript--name-start-re)
       (list (concat "\\(" typescript--name-re "\\)\\(\\s-*).*\\)?")
             '(backward-char)
@@ -2018,7 +2018,6 @@ This performs fontification according to `typescript--class-styles'."
 
     ;; highlights that append to previous levels
     ;;
-    ,@typescript--font-lock-keywords-2
     ,@typescript--font-lock-keywords-3
 
     (,typescript--decorator-re (1 font-lock-function-name-face))

--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -270,10 +270,12 @@ Match group 1 is MUMBLE.")
   (typescript--regexp-opt-symbol
    '("abstract" "any" "as" "async" "await" "boolean" "bigint" "break" "case" "catch" "class" "const"
      "constructor" "continue" "declare" "default" "delete" "do" "else"
-     "enum" "export" "extern" "finally" "for" "function" "from" "get"
-     "goto" "if" "implements" "import" "in" "instanceof" "interface" "keyof"
-     "let" "module" "namespace" "new" "of" "return" "set" "super" "switch"
-     "throw" "true" "try" "type" "typeof" "unknown" "var"
+     "enum" "export" "extends" "extern" "false" "finally" "for"
+     "function" "from" "get" "goto" "if" "implements" "import" "in" "instanceof"
+     "interface" "keyof" "let" "module" "namespace" "never" "new" "null" "number" "object" "of"
+     "private" "protected" "public" "readonly" "return" "set" "static" "string"
+     "super" "switch"  "this" "throw" "true"
+     "try" "type" "typeof" "unknown" "var" "void"
      "while")) ; yield is handled separately
   "Regexp matching any typescript keyword.")
 
@@ -295,7 +297,7 @@ Match group 1 is MUMBLE.")
   (typescript--regexp-opt-symbol '("false" "null" "undefined"
                                  "Infinity" "NaN"
                                  "true" "arguments"))
-  "Regular expression matching constant values.")
+  "Regular expression matching builtin values.")
 
 (defconst typescript--builtin-re
   (typescript--regexp-opt-symbol

--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -1839,9 +1839,9 @@ and searches for the next token to be highlighted."
      (1 font-lock-type-face))
 
     ;; variable declarations
-    ,(list
-      (concat "\\_<\\(const\\|var\\|let\\)\\_>\\|" typescript--basic-type-re)
-      (list #'typescript--variable-decl-matcher nil nil nil))
+    ;; ,(list
+    ;;   (concat "\\_<\\(const\\|var\\|let\\)\\_>\\|" typescript--basic-type-re)
+    ;;   (list #'typescript--variable-decl-matcher nil nil nil))
 
     ;; class instantiation
     ,(list


### PR DESCRIPTION
Addressed #79.

This pull request contains the beginnings of the work to add additional fontification to `typescript-mode`.

So far, the following changes have been implemented as a 4th level of highlighting:

- [x] function calls (`font-lock-function-name-face`)
- [x] function definitions in classes (`font-lock-function-name-face`)
- [x] decorators (`font-lock-function-name-face`)
- [x] builtins (right now just `console`, as `font-lock-type-face`)
- [x] access modifiers (`private`, `public`, etc. as `typescript-access-modifier-face` - inherits `font-lock-keyword-face`
- [x] type hints in generics (`font-lock-type-face`)
- [x] basic types (`any`, `string`, `boolean`, etc. as `typescript-primitive-face` - inherits `font-lock-keyword-face`
- [x] moved constants (false, NaN, etc) to `font-lock-variable-name-face` for more contrast (only for this 4th level)
- [x] `this` keyword (`typescript-this-face` - inherits `font-lock-keyword-face`)

Currently, the changes remain very simple and purely regexp based. This will probably have to change to properly support type hints, but I haven't yet been able to fully wrap my head around the whole `pitem` system.

Also, there are no tests are documentation or anything yet, but can add that if this gets more traction.

Remaining:
- [ ] type hints
- [ ] tests