### PR TITLE
better generics support

### DIFF
--- a/typescript-mode-general-tests.el
+++ b/typescript-mode-general-tests.el
@@ -319,6 +319,36 @@ declare function declareFunctionDefn(x3: xty3, y3: yty3): ret3;"
       (("y0" "y1" "y2" "y3") . font-lock-variable-name-face)
       (("ret0" "ret1" "ret2" "ret3") . nil))))
 
+(ert-deftest font-lock/level-four ()
+  "Tests the level four font lock highlights."
+  (font-lock-test
+   "@decorator\n
+class Foo<T> extends Bar {\n
+private async innerExecuteAsync<TResponse extends Response, TValue>(endpoint: string, data?: any): Promise<TResponse> {\n
+innerExecuteAsync(x: string, y: boolean, z: number, j?: any): Promise<FResponse> {\n
+console.log(this.methodCall())"
+    '(("@decorator" . font-lock-function-name-face)
+      ("Foo" . font-lock-type-face)
+      ("private" . typescript-access-modifier-face)
+      ("innerExecuteAsync" . font-lock-function-name-face)
+      (("TResponse" "FResponse" "Response" "TValue") . font-lock-type-face)
+      ("console" . font-lock-type-face)
+      ("this" . typescript-this-face)
+      ("methodCall" . font-lock-function-name-face)
+      (("string" "boolean" "number" "any") . typescript-primitive-face)
+      (("endpoint" "data") . nil)
+      (("<" ">" ",") . nil))))
+
+(ert-deftest font-lock/generics ()
+  "Tests that type hints within generics are highlighted properly."
+  (font-lock-test
+   "const map = new Map<string, number>()\n
+function foo<Z, Y, Z & Y, Z | Y | Z, Y<X<X, Y>>>()\n"
+   '((("string" "number") . typescript-primitive-face)
+      ("foo" . font-lock-function-name-face)
+      (("Z" "Y" "X") . font-lock-type-face)
+      (("<" ">" "," "&" "|") . nil))))
+
 (ert-deftest font-lock/regexp ()
   "Regular expresssions should be fontified as string constant."
   (let ((content "=/foo/ (/bar/ ,/baz/ :/buzz/"))

--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -283,14 +283,6 @@ Match group 1 is MUMBLE.")
    '("private" "protected" "public" "readonly" "static" "extends" "implements"))
   "Regular expression matching access modifiers.")
 
-(defconst typescript--generic-type-re
-  "<\\(.*\\)>"
-   "Regular expression matching generic types.")
-
-(defconst typescript--generic-type-extended-re
-  (concat "<\\(.*\\)extends\\(.*\\)>")
-   "Regular expression matching generic types with extension.")
-
 (defconst typescript--decorator-re
   (concat "\\(@" typescript--name-re "\\)"))
 
@@ -1878,7 +1870,7 @@ and searches for the next token to be highlighted."
     ;; formal parameters
     ,(list
       (concat
-       "\\_<function\\_>\\(\\s-+" typescript--name-re "\\)?\\s-*(\\s-*"
+       "\\_<function\\_>\\(\\s-+" typescript--name-re "\\)?\\s-*\\(<.*>\\)?\\s-*(\\s-*"
        typescript--name-start-re)
       (list (concat "\\(" typescript--name-re "\\)\\(\\s-*).*\\)?")
             '(backward-char)
@@ -1982,7 +1974,7 @@ context."
     (when (called-interactively-p 'interactive)
       (message "Syntactic context: %s" syntactic-context))
 
-    syntactic-context))
+   syntactic-context))
 
 (defun typescript--class-decl-matcher (limit)
   "Font lock function used by `typescript-mode'.
@@ -2016,6 +2008,14 @@ This performs fontification according to `typescript--class-styles'."
     (,typescript--access-modifier-re (1 'typescript-access-modifier-face))
     (,typescript--basic-type-re (1 'typescript-primitive-face))
 
+    ;; generics support
+    ,(list
+      (concat "<\\s-*" typescript--name-start-re)
+      (list (concat "\\(" typescript--name-re "\\)\\(\\s-*>[^<]*\\)?")
+            '(backward-char)
+            '(end-of-line)
+            '(1 font-lock-type-face)))
+
     ;; highlights that append to previous levels
     ;;
     ,@typescript--font-lock-keywords-3
@@ -2023,9 +2023,6 @@ This performs fontification according to `typescript--class-styles'."
     (,typescript--decorator-re (1 font-lock-function-name-face))
     (,typescript--function-call-re (1 font-lock-function-name-face))
     (,typescript--builtin-re (1 font-lock-type-face))
-
-    (,typescript--generic-type-re (1 font-lock-type-face))
-    (,typescript--generic-type-extended-re (1 font-lock-type-face))
 
     ;; arrow function
     ("\\(=>\\)"


### PR DESCRIPTION
follow up to issue #79 and PR #110.

This should
1) Give better support for highlighting generic types
2) fix function args highlighting when function is defined with generic arg

It does NOT
1) support multiline generic arguments


@josteink I'll either add tests here or to a separate PR. try this out for a bit and see if you spot any bugs