### PR TITLE
Update CI-settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-dist: trusty
 language: generic
 sudo: false
 before_install:
@@ -13,7 +12,9 @@ env:
   - EVM_EMACS=emacs-25.1-travis
   - EVM_EMACS=emacs-25.2-travis
   - EVM_EMACS=emacs-25.3-travis
-  - EVM_EMACS=emacs-26.1-travis
+  - EVM_EMACS=emacs-26.1-travis-linux-xenial
+  - EVM_EMACS=emacs-26.2-travis-linux-xenial
+  - EVM_EMACS=emacs-26.3-travis-linux-xenial
   - EVM_EMACS=emacs-git-snapshot-travis
 
 matrix:


### PR DESCRIPTION
- Add support for all Emacs 26.x versions
- Don’t pin CI to trusty.