### PR TITLE
add a test for simple tsx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM ubuntu:bionic
+
+RUN apt-get update && \
+  apt-get install -y \
+  make curl python git emacs
+
+RUN curl -fsSL https://raw.githubusercontent.com/cask/cask/master/go | python
+ENV PATH="/root/.cask/bin:${PATH}"
+
+RUN mkdir -p /home/typescript.el
+COPY . /home/typescript.el
+WORKDIR /home/typescript.el
+
+CMD ["make", "test"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ RUN apt-get update && \
 RUN curl -fsSL https://raw.githubusercontent.com/cask/cask/master/go | python
 ENV PATH="/root/.cask/bin:${PATH}"
 
-RUN mkdir -p /home/typescript.el
-COPY . /home/typescript.el
-WORKDIR /home/typescript.el
+RUN mkdir -p /typescript-mode
+COPY . /typescript-mode
+WORKDIR /typescript-mode
 
 CMD ["make", "test"]

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ To run the tests you can run `make test`.
 If you prefer, you may run the tests via the provided `Dockerfile`.
 
 ```bash
-docker build -t typescript.el .
-docker run --rm -v $(pwd):/home/typescript.el typescript.el
+docker build -t typescript-mode .
+docker run --rm -v $(pwd):/typescript-mode typescript-mode
 ```
 
 # Other Typescript-packages of interest

--- a/README.md
+++ b/README.md
@@ -50,6 +50,17 @@ to `false`: `tsc --pretty false`. However, doing this does more than
 just turning off the colors. It also causes `tsc` to produce less
 elaborate error messages.
 
+# Contributing
+
+To run the tests you can run `make test`.
+
+If you prefer, you may run the tests via the provided `Dockerfile`.
+
+```bash
+docker build -t typescript.el .
+docker run --rm -v $(pwd):/home/typescript.el typescript.el
+```
+
 # Other Typescript-packages of interest
 
 While `typescript.el` may *not* provide a full kitchen-sink, the good

--- a/typescript-mode-general-tests.el
+++ b/typescript-mode-general-tests.el
@@ -349,6 +349,12 @@ function foo<Z, Y, Z & Y, Z | Y | Z, Y<X<X, Y>>>()\n"
       (("Z" "Y" "X") . font-lock-type-face)
       (("<" ">" "," "&" "|") . nil))))
 
+(ert-deftest font-lock/tsx ()
+  "Tests that tsx blocks are not considered generics by virtue of the <."
+  (font-lock-test
+   "<div>test</div>"
+   '((("div" . nil)))))
+
 (ert-deftest font-lock/regexp ()
   "Regular expresssions should be fontified as string constant."
   (let ((content "=/foo/ (/bar/ ,/baz/ :/buzz/"))


### PR DESCRIPTION
This adds a missing test for #119. 

It also includes a `Dockerfile` and some instructions that can ease testing.

Currently, the case provided in the test is `<div>test</div>`and `div`is not treated as a generic.

However, a case with multiple tags on a  line like `<div>test <span>me</span></div>` would indeed highlight the `span` as a generic type. Still open to solutions for this, although I personally just recommend web-mode for this