### PR TITLE
Smartparens compatibility

### DIFF
--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -743,28 +743,11 @@ the string from a plain string to a template."
 
 (defvar typescript-mode-map
   (let ((keymap (make-sparse-keymap)))
-    (dolist (key '("{" "}" "(" ")" ":" ";" ","))
-      (define-key keymap key #'typescript-insert-and-indent))
     (dolist (key '("\"" "\'"))
       (define-key keymap key #'typescript-insert-and-autoconvert-to-template))
     (define-key keymap (kbd "C-c '") #'typescript-convert-to-template)
     keymap)
   "Keymap for `typescript-mode'.")
-
-(defun typescript-insert-and-indent (key)
-  "Run the command bound to KEY, and indent if necessary.
-Indentation does not take place if point is in a string or
-comment."
-  (interactive (list (this-command-keys)))
-  (call-interactively (lookup-key (current-global-map) key))
-  (let ((syntax (save-restriction (widen) (syntax-ppss))))
-    (when (or (and (not (nth 8 syntax))
-                   typescript-auto-indent-flag)
-              (and (nth 4 syntax)
-                   (eq (current-column)
-                       (1+ (current-indentation)))))
-      (indent-according-to-mode))))
-(put 'typescript-insert-and-indent 'delete-selection t)
 
 (defun typescript-insert-and-autoconvert-to-template (key)
   "Run the command bount to KEY, and autoconvert to template if necessary."
@@ -2844,6 +2827,9 @@ Key bindings:
         c-line-comment-starter "//"
         c-comment-start-regexp "/[*/]\\|\\s!"
         comment-start-skip "\\(//+\\|/\\*+\\)\\s *")
+
+  (setq-local electric-indent-chars
+	      (append "{}():;," electric-indent-chars))
 
   (let ((c-buffer-is-cc-mode t))
     ;; FIXME: These are normally set by `c-basic-common-init'.  Should

--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -743,19 +743,16 @@ the string from a plain string to a template."
 
 (defvar typescript-mode-map
   (let ((keymap (make-sparse-keymap)))
-    (dolist (key '("\"" "\'"))
-      (define-key keymap key #'typescript-insert-and-autoconvert-to-template))
     (define-key keymap (kbd "C-c '") #'typescript-convert-to-template)
     keymap)
   "Keymap for `typescript-mode'.")
 
-(defun typescript-insert-and-autoconvert-to-template (key)
-  "Run the command bount to KEY, and autoconvert to template if necessary."
-  (interactive (list (this-command-keys)))
-  (call-interactively (lookup-key (current-global-map) key))
-  (when typescript-autoconvert-to-template-flag
+(defun typescript--post-self-insert-function ()
+  (when (and (derived-mode-p 'typescript-mode)
+             typescript-autoconvert-to-template-flag
+             (or (eq last-command-event ?\')
+                 (eq last-command-event ?\")))
     (typescript-autoconvert-to-template)))
-(put 'typescript-insert-and-autoconvert-to-template 'delete-selection t)
 
 ;;; Syntax table and parsing
 
@@ -2842,6 +2839,9 @@ Key bindings:
     (make-local-variable 'adaptive-fill-mode)
     (make-local-variable 'adaptive-fill-regexp)
     (c-setup-paragraph-variables))
+
+  (add-hook 'post-self-insert-hook
+            #'typescript--post-self-insert-function)
 
   (setq-local syntax-begin-function #'typescript--syntax-begin-function))
 

--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -2830,6 +2830,8 @@ Key bindings:
 
   (setq-local electric-indent-chars
 	      (append "{}():;," electric-indent-chars))
+  (setq-local electric-layout-rules
+	      '((?\; . after) (?\{ . after) (?\} . before)))
 
   (let ((c-buffer-is-cc-mode t))
     ;; FIXME: These are normally set by `c-basic-common-init'.  Should


### PR DESCRIPTION
Closes #118 

Hooking into the `electric-indent-mode` takes care of most problems.

For the quotes, the functionality is reimplemented as a `post-self-insert-hook`. I have some reservations about this because the `post-self-insert-hook` is really Emacs-wide but the auto-conversion is meant to happen only in buffers where `typescript-mode` is the major mode. I've tried a few other approaches but they all ran into issues.

@josteink Opinion about the use of `post-self-insert-hook` here?