### PR TITLE
Fix member expression indentation

### DIFF
--- a/test-files/indentation-reference-document.ts
+++ b/test-files/indentation-reference-document.ts
@@ -663,3 +663,57 @@ let $img2: JQuery<HTMLImageElement> = null
 if (variable != null) {
     //
 }
+
+// The following block deals with strings of member expressions on so-called
+// "fluent" APIs.
+interface Fnord {
+    log(...args: any[]): this;
+    blah(): this;
+}
+
+let fnord: Fnord = {} as any;
+
+{
+    fnord
+        .log("sdf")
+        .blah();
+
+    const m =
+        fnord
+            .log()
+            .blah();
+
+    const b = { q: 1, f: 2}
+
+    const x =
+        fnord
+            .log({ a: b.q, z: b.f })
+            .blah();
+
+    (async () => {
+        const x = (
+            await (fnord as any)
+                .log(1));
+    })();
+}
+
+fnord
+    .log("sdf")
+    .blah();
+
+const m =
+    fnord
+        .log()
+        .blah();
+
+fnord
+    .log("sdf")
+
+const q =
+    fnord
+        .log();
+
+// This is a continued expression in parentheses.
+const blip999 = (window.location.href === "fnord" ?
+    "a" :
+    "b");


### PR DESCRIPTION
Prior to this change, we'd get nonsense like this:

```
fnord
    .log("sdf")
    .blah();

const m =
    fnord
    .log()
    .blah();
```

The second `fnord` does not have the member expressions indented one step higher than `fnord` itself, but the first does. Why? Why? Why? Why, oh why? There's no rhyme or reason.

This PR fixes the algorithm in favor of the first indentation. That is, after the fix:

```
fnord
    .log("sdf")
    .blah();

const m =
    fnord
        .log()
        .blah();
```

I'll note that the fixed algorithm conforms to what `tide-format` does.

----

While fixing the above, I ran into a related issue. Here's an example of indented code prior to this PR:

```
const blip999 = (window.location.href === "fnord" ?
                 "a" :
                 "b");
```

The opening parenthesis serves as the reference point for further indentation. This diverges from what `tide-format` does. (And what my `eslint` configuration does when I ask it to fix a file.)

The PR changes the indentation code to get:

```
const blip999 = (window.location.href === "fnord" ?
    "a" :
    "b");
```

This conforms to what `tide-format` (and any other tool I use for formatting TS code) does. The only context in which I can reproduce the prior behavior is by using `js2-mode` to edit JS code.

I'm going to leave this up for one week prior to merging so those who wish to comment may do so.