### PR TITLE
Fix indentation infinite looping

### DIFF
--- a/test-files/indentation-reference-document.ts
+++ b/test-files/indentation-reference-document.ts
@@ -724,3 +724,7 @@ const blip999 = (window.location.href === "fnord" ?
 if (true) {
     .bleh();
 }
+
+) {
+    1 + 2; // Indenting this line would cause an infinite loop
+}

--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -2432,7 +2432,7 @@ moved on success."
                                  (looking-at "\\_<\\(switch\\|if\\|while\\|until\\|for\\)\\_>\\(?:\\s-\\|\n\\)*(")))))
                     (condition-case nil
                         (backward-sexp)
-                      (scan-error nil)))
+                      (scan-error (cl-return-from search-loop nil))))
                    ((looking-back typescript--number-literal-re
                                   ;; We limit the search back to the previous space or end of line (if possible)
                                   ;; to prevent the search from going over the whole buffer.

--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -2478,7 +2478,9 @@ moved on success."
                        ;; In that case, we want the code that follows to see the indentation
                        ;; that was in effect at the beginning of the function declaration, and thus
                        ;; we want to move back over the list of function parameters.
-                       (backward-list))
+                       (condition-case nil
+                           (backward-list)
+                         (error nil)))
                       ((looking-back "," nil)
                        ;; If we get here, we have a comma, spaces and an opening curly brace. (And
                        ;; (point) is just after the comma.) We don't want to move from the current position


### PR DESCRIPTION
With unbalanced parentheses typescript--backward-to-parameter-list goes in to an infinite loop.