### PR TITLE
Add syntax-highlighting for types in variable-declarations

### DIFF
--- a/typescript-mode-general-tests.el
+++ b/typescript-mode-general-tests.el
@@ -464,6 +464,54 @@ function foo<Z, Y, Z & Y, Z | Y | Z, Y<X<X, Y>>>()\n"
       "type Thing = number;"
     (should (eq (get-face-at "Thing") 'font-lock-type-face))))
 
+(ert-deftest font-lock/type-names-level4 ()
+  "Typenames should be highlighted in declarations"
+
+  (test-with-fontified-buffer
+      "function test(var1: Type1, var2: Type2): RetType {\n}"
+    (should (not (eq (get-face-at "var1") 'font-lock-type-face)))
+    (should (eq (get-face-at "Type1") 'font-lock-type-face))
+    (should (not (eq (get-face-at "var2") 'font-lock-type-face)))
+    (should (eq (get-face-at "Type2") 'font-lock-type-face))
+    (should (eq (get-face-at "RetType") 'font-lock-type-face)))
+
+  (test-with-fontified-buffer
+      "class foo { test(var1: Type1, var2: Type2): RetType {\n} }"
+    (should (not (eq (get-face-at "var1") 'font-lock-type-face)))
+    (should (eq (get-face-at "Type1") 'font-lock-type-face))
+    (should (not (eq (get-face-at "var2") 'font-lock-type-face)))
+    (should (eq (get-face-at "Type2") 'font-lock-type-face))
+    (should (eq (get-face-at "RetType") 'font-lock-type-face)))
+
+  (test-with-fontified-buffer
+      "let a: SomeType;"
+    (should (eq (get-face-at "SomeType") 'font-lock-type-face)))
+  (test-with-fontified-buffer
+      "private b: SomeType;"
+    (should (eq (get-face-at "SomeType") 'font-lock-type-face)))
+  (test-with-fontified-buffer
+      "private someArray: SomeType[];"
+    (should (eq (get-face-at "SomeType") 'font-lock-type-face)))
+  (test-with-fontified-buffer
+      "private generic: SomeType<Foo>;"
+    (should (eq (get-face-at "SomeType") 'font-lock-type-face))
+    (should (eq (get-face-at "Foo") 'font-lock-type-face)))
+
+  (test-with-fontified-buffer
+      "private genericArray: SomeType<Foo>[];"
+    (should (eq (get-face-at "SomeType") 'font-lock-type-face))
+    (should (eq (get-face-at "Foo") 'font-lock-type-face)))
+
+  (test-with-fontified-buffer
+      "private genericArray2: SomeType<Foo[]>;"
+    (should (eq (get-face-at "SomeType") 'font-lock-type-face))
+    (should (eq (get-face-at "Foo") 'font-lock-type-face)))
+
+  (test-with-fontified-buffer
+      "private genericArray3: SomeType<Foo[]>[];"
+    (should (eq (get-face-at "SomeType") 'font-lock-type-face))
+    (should (eq (get-face-at "Foo") 'font-lock-type-face))))
+
 (defun flyspell-predicate-test (search-for)
   "This function runs a test on
 `typescript--flyspell-mode-predicate'.  `SEARCH-FOR' is a string

--- a/typescript-mode-general-tests.el
+++ b/typescript-mode-general-tests.el
@@ -512,6 +512,32 @@ function foo<Z, Y, Z & Y, Z | Y | Z, Y<X<X, Y>>>()\n"
     (should (eq (get-face-at "SomeType") 'font-lock-type-face))
     (should (eq (get-face-at "Foo") 'font-lock-type-face))))
 
+(ert-deftest font-lock/type-names-level4-namespaces ()
+  "Namespaced Typenames should be highlighted in declarations"
+  (test-with-fontified-buffer
+      "private b: Namespaced.ClassName;"
+    (should (eq (get-face-at "Namespaced") 'font-lock-type-face))
+    (should (eq (get-face-at "ClassName") 'font-lock-type-face)))
+  (test-with-fontified-buffer
+      "function test(var1: Namespaced.ClassName): RetType {\n}"
+    (should (eq (get-face-at "Namespaced") 'font-lock-type-face))
+    (should (eq (get-face-at "ClassName") 'font-lock-type-face)))
+
+  (test-with-fontified-buffer
+      "class Foo { test(var1: Namespaced.ClassName): RetType {\n}"
+    (should (eq (get-face-at "Namespaced") 'font-lock-type-face))
+    (should (eq (get-face-at "ClassName") 'font-lock-type-face)))
+
+  (test-with-fontified-buffer
+      "function test(var1: Type): Namespaced.ClassName {\n}"
+    (should (eq (get-face-at "Namespaced") 'font-lock-type-face))
+    (should (eq (get-face-at "ClassName") 'font-lock-type-face)))
+
+  (test-with-fontified-buffer
+      "class Foo { test(var1: Type): Namespaced.ClassName {\n}"
+    (should (eq (get-face-at "Namespaced") 'font-lock-type-face))
+    (should (eq (get-face-at "ClassName") 'font-lock-type-face))))
+
 (defun flyspell-predicate-test (search-for)
   "This function runs a test on
 `typescript--flyspell-mode-predicate'.  `SEARCH-FOR' is a string

--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -1997,6 +1997,18 @@ This performs fontification according to `typescript--class-styles'."
             '(end-of-line)
             '(1 font-lock-type-face)))
 
+    ;; type-highlighting in variable/parameter declarations
+    ;; supports a small variety of common declarations:
+    ;; - let a: SomeType;
+    ;; - private b: SomeType;
+    ;; - private someFunc(var: SomeType) {
+    ;; - private array: SomeType[]
+    ;; - private generic: SomeType<Foo>
+    ;; - private genericArray: SomeType<Foo>[]
+    ;; - function testFunc(): SomeType<> {
+    (":\\s-\\([A-Z][A-Za-z0-9]+\\)\\(<[A-Z][A-Za-z0-9]+>\\)?\\(\[\]\\)?\\([,;]\\)?\\s-*{?"
+     (1 'font-lock-type-face))
+
     ;; highlights that append to previous levels
     ;;
     ,@typescript--font-lock-keywords-3

--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -2009,6 +2009,10 @@ This performs fontification according to `typescript--class-styles'."
     (":\\s-\\([A-Z][A-Za-z0-9]+\\)\\(<[A-Z][A-Za-z0-9]+>\\)?\\(\[\]\\)?\\([,;]\\)?\\s-*{?"
      (1 'font-lock-type-face))
 
+    ;; type-casts
+    ("<\\([A-Z][A-Za-z0-9]+\\)>"
+     (1 'font-lock-type-face))
+
     ;; highlights that append to previous levels
     ;;
     ,@typescript--font-lock-keywords-3

--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -63,6 +63,9 @@
 
 ;;; Constants
 
+(defconst typescript--type-name-re "[A-Z][A-Za-z0-9]+"
+  "Regexp matching a conventional TypeScript type-name.  Must start with upper-case letter!")
+
 (defconst typescript--name-start-re "[a-zA-Z_$]"
   "Regexp matching the start of a typescript identifier, without grouping.")
 
@@ -2006,12 +2009,15 @@ This performs fontification according to `typescript--class-styles'."
     ;; - private generic: SomeType<Foo>
     ;; - private genericArray: SomeType<Foo>[]
     ;; - function testFunc(): SomeType<> {
-    (":\\s-\\([A-Z][A-Za-z0-9]+\\)\\(<[A-Z][A-Za-z0-9]+>\\)?\\(\[\]\\)?\\([,;]\\)?\\s-*{?"
-     (1 'font-lock-type-face))
+    ;; TODO: namespaced classes!
+    ,(list
+      (concat ":\\s-\\(" typescript--type-name-re "\\)\\(<" typescript--type-name-re ">\\)?\\(\[\]\\)?\\([,;]\\)?\\s-*{?")
+      '(1 'font-lock-type-face))
 
     ;; type-casts
-    ("<\\([A-Z][A-Za-z0-9]+\\)>"
-     (1 'font-lock-type-face))
+    ,(list
+      (concat "<\\(" typescript--type-name-re "\\)>")
+      '(1 'font-lock-type-face))
 
     ;; highlights that append to previous levels
     ;;

--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -63,7 +63,7 @@
 
 ;;; Constants
 
-(defconst typescript--type-name-re "[A-Z][A-Za-z0-9]+"
+(defconst typescript--type-name-re "\\(?:[A-Z][A-Za-z0-9]+\\.\\)\\{0,\\}\\(?:[A-Z][A-Za-z0-9]+\\)"
   "Regexp matching a conventional TypeScript type-name.  Must start with upper-case letter!")
 
 (defconst typescript--name-start-re "[a-zA-Z_$]"


### PR DESCRIPTION
As mentioned in https://github.com/emacs-typescript/typescript.el/issues/112#issuecomment-580188854:

> so far it handles the following cases fine:
>
> - let a: SomeType;
> - private b: SomeType;
> - private someFunc(var: SomeType) {
> - private array: SomeType[]
> - private generic: SomeType\<Foo\>
> - private genericArray: SomeType\<Foo\>[]
> - function testFunc(): SomeType\<\> {>
> ...
>
> For now I'm letting this change live in a feature-branch to see if it causes any obvious negative/incorrect highlightings.
>
> If it doesn't, I think I may be leaning towards wanting this merged to master, because it really helps distinguish types in type-heavy projects.

I've been giving this branch a go as my "main" typescript-mode for over a month now, and I'm considering it a 100% positive change. Whenever I'm back at `master` I'm *aching* for those highlighted type-declarations, and I've yet to find any adverse or weird highlightings in any idiomatic TypeScript-code I've touched.

I'm all for the conceptual purity of having highlighting based on an actual, proper syntax-analysis (as promoted by @lddubeau ), but in the mean time I'm also realistic enough to see that's not going to happen anytime soon. 

That leaves the pragmatic parts of me wanting this noticable improvement, even though it's not done 100% "proper".

In short: I'm now 100% in support of this change.

If anyone has any idiomatic code which gets highlighted incorrectly based on these change, please do let me know.

Otherwise I'd now like to start the count-down clock for getting this branch merged.

Any disagreements on that part? Anyone who would feel highly upset over this change?

Not to mention: Any actual constructive criticism of the code here is very much wanted.

cc: @lddubeau , @tam5,  @Fuco1