### PR TITLE
* typescript-mode.el: Use EOS instead of EOL for auto mode regexp.

### DIFF
--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -2978,7 +2978,7 @@ Key bindings:
      (folding-add-to-marks-list 'typescript-mode "// {{{" "// }}}" )))
 
 ;;;###autoload
-(add-to-list 'auto-mode-alist '("\\.ts$" . typescript-mode))
+(add-to-list 'auto-mode-alist '("\\.ts\\'" . typescript-mode))
 
 (provide 'typescript-mode)
 


### PR DESCRIPTION
This prevent matching filename like "xxxx.ts\nxxxx". A corner case which satisfies POSIX filename standard but weird for daily use.