### PR TITLE
fix eval invocation in typescript--re-search-backward to work with lexical scoping

### DIFF
--- a/typescript-mode-lexical-binding-tests.el
+++ b/typescript-mode-lexical-binding-tests.el
@@ -1,0 +1,25 @@
+;; -*- lexical-binding: t -*-
+;;; typescript-mode-lexical-binding-tests --- This file contains test for typescript-mode.el under enabled lexical-binding
+
+;;; Commentary:
+;; To know how to run the tests, see typescript-mode-tests.el
+
+(require 'ert)
+
+;; reload typescript-mode with lexical-binding enabled
+(with-temp-buffer
+  (insert-file-contents "typescript-mode.el")
+  (ignore-errors
+    (while (setq sexp (read (current-buffer)))
+      (eval sexp t))))
+
+(require 'typescript-mode-test-utilities)
+
+(ert-deftest lexical-binding--indentation-does-not-throw-error ()
+  (with-temp-buffer
+    (insert-file-contents "test-files/indentation-reference-document.ts")
+    (typescript-mode)
+    (goto-line 2)
+    (typescript-indent-line)))
+
+(provide 'typescript-mode-lexical-binding-tests)

--- a/typescript-mode-tests.el
+++ b/typescript-mode-tests.el
@@ -11,6 +11,7 @@
 (require 'typescript-mode-test-utilities)
 (require 'typescript-mode-general-tests)
 (require 'typescript-mode-jsdoc-tests)
+(require 'typescript-mode-lexical-binding-tests)
 
 (provide 'typescript-mode-tests)
 

--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -992,11 +992,11 @@ one at the end of the line with \"let a\"."
   (let ((saved-point (point))
         (search-expr
          (cond ((null count)
-                '(typescript--re-search-backward-inner regexp bound 1))
+                `(typescript--re-search-backward-inner ,regexp ,bound 1))
                ((< count 0)
-                '(typescript--re-search-forward-inner regexp bound (- count)))
+                `(typescript--re-search-forward-inner ,regexp ,bound (- ,count)))
                ((> count 0)
-                '(typescript--re-search-backward-inner regexp bound count)))))
+                `(typescript--re-search-backward-inner ,regexp ,bound ,count)))))
     (condition-case err
         (eval search-expr)
       (search-failed


### PR DESCRIPTION
Under lexical scoping variable references won't be found when evaluating the expression, resulting in "eval: Symbol’s value as variable is void: regexp" error.

By the way, do we really need the `eval` here?