### PR TITLE
Skip past ? and ! in typescript--compute-member-expression-indent

### DIFF
--- a/typescript-mode-general-tests.el
+++ b/typescript-mode-general-tests.el
@@ -204,6 +204,14 @@ a severity set to WARNING, no rule name."
     (forward-char 1)
     (should (= 8 (current-column)))))
 
+(ert-deftest correctly-indents-dot-dot-after-exclamation ()
+  (with-temp-buffer
+    (ignore-errors (typescript-mode))
+    (insert "situation('8/8/8/8/8/8/8/R3K2R w - - 0 1')?.")
+    (forward-char -1)
+    (newline-and-indent)
+    (should (= 4 (current-column)))))
+
 (ert-deftest indentation-does-not-hang-on-multiline-string ()
   "Testcase for https://github.com/ananthakumaran/typescript.el/issues/20"
 

--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -2308,6 +2308,8 @@ starts the member expression.
     (typescript--backward-syntactic-ws)
     (while (eq (char-before) ?\;)
       (backward-char))
+    (when (memq (char-before) '(?\? ?\!))
+      (backward-char))
     (while (memq (char-before) '(?\] ?} ?\) ?>))
       (if (not (eq (char-before) ?>))
           (backward-list)


### PR DESCRIPTION
fixes #146 

This PR fixest the  `typescript--compute-member-expression-indent` function in the case that there is a `?` or a `!` before the dot that a new line was created before.

I also noticed that many other characters in this position (having invalid syntax) cause the editor to hang like `@` or `"`.  I was thinking of using the character syntax class to skip over these symbols as well. Let me know if you think this is a good idea to cover these additional cases in addition to `!` and `?`.