### PR TITLE
Fix cl deprecation warning

### DIFF
--- a/typescript-mode-general-tests.el
+++ b/typescript-mode-general-tests.el
@@ -7,7 +7,7 @@
 
 (require 'ert)
 (require 'typescript-mode)
-(require 'cl)
+(require 'cl-lib)
 (require 'typescript-mode-test-utilities)
 
 (defun typescript-test-get-doc ()

--- a/typescript-mode-tests.el
+++ b/typescript-mode-tests.el
@@ -7,7 +7,7 @@
 
 (require 'ert)
 (require 'typescript-mode)
-(require 'cl)
+(require 'cl-lib)
 (require 'typescript-mode-test-utilities)
 (require 'typescript-mode-general-tests)
 (require 'typescript-mode-jsdoc-tests)


### PR DESCRIPTION
This commit replaces `cl `with `cl-lib` to remove deprecation warning on Emacs 27 and onward (see deprecation [note](https://github.com/emacs-mirror/emacs/blob/8758c96dc7f252944eb97b95c92081b157084477/etc/NEWS#L601)).

## Steps to reproduce
- Install `typescript`
- Run Emacs v27 (e.g. 27.2)
- Observe the deprecation warning

```
Package cl is deprecated
```
