### PR TITLE
capitalize mode name "TypeScript"

### DIFF
--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -2911,7 +2911,7 @@ the broken-down class name of the item to insert."
 ;;; Main Function
 
 ;;;###autoload
-(define-derived-mode typescript-mode prog-mode "typescript"
+(define-derived-mode typescript-mode prog-mode "TypeScript"
   "Major mode for editing typescript.
 
 Key bindings:


### PR DESCRIPTION
I realize this is picky, but TypeScript is a name, and like names (and titles), they should be capitalized. Thanks for the light-weight major mode!

![Screenshot from 2022-02-18 16-26-30](https://user-images.githubusercontent.com/28788713/154777953-cf41a48e-d243-45e3-aeb9-d12e088d9ca5.png)

vs

![Screenshot from 2022-02-18 16-27-05](https://user-images.githubusercontent.com/28788713/154777990-877093cf-4abb-42aa-8f44-8d35c0f51bdb.png) 
