### PR TITLE
Fix CI test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,14 +9,14 @@ on:
   workflow_dispatch:
 
 jobs:
-  unix-build:
+  build:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         experimental: [false]
-        emacs: [26.1, 26.2, 26.3, 27.1, 27.2, 28.1]
+        emacs_version: [26.1, 26.2, 26.3, 27.1, 27.2, 28.1]
         include:
         - emacs: snapshot
           experimental: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,13 +18,13 @@ jobs:
         experimental: [false]
         emacs-version: [26.1, 26.2, 26.3, 27.1, 27.2, 28.1]
         include:
-        - emacs: snapshot
+        - emacs-version: snapshot
           experimental: true
           os: ubuntu-latest
-        - emacs: snapshot
+        - emacs-version: snapshot
           experimental: true
           os: macos-latest
-        - emacs: snapshot
+        - emacs-version: snapshot
           experimental: true
           os: windows-latest
     continue-on-error: ${{ matrix.experimental }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: '16'
 
       - uses: emacs-eask/setup-eask@master
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         experimental: [false]
-        emacs_version: [26.1, 26.2, 26.3, 27.1, 27.2, 28.1]
+        emacs-version: [26.1, 26.2, 26.3, 27.1, 27.2, 28.1]
         include:
         - emacs: snapshot
           experimental: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,9 +14,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         experimental: [false]
-        emacs: [26.1, 26.2, 26.3, 27.1, 27.2]
+        emacs: [26.1, 26.2, 26.3, 27.1, 27.2, 28.1]
         include:
         - emacs: snapshot
           experimental: true
@@ -24,56 +24,34 @@ jobs:
         - emacs: snapshot
           experimental: true
           os: macos-latest
+        - emacs: snapshot
+          experimental: true
+          os: windows-latest
     continue-on-error: ${{ matrix.experimental }}
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-python@v2
-        with:
-          python-version: "3.6"
-          architecture: "x64"
-
       - uses: purcell/setup-emacs@master
+        if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
         with:
-          version: ${{ matrix.emacs }}
+          version: ${{ matrix.emacs-version }}
 
-      - uses: conao3/setup-cask@master
+      - uses: jcs090218/setup-emacs-windows@master
+        if: matrix.os == 'windows-latest'
         with:
-          version: 0.8.4
+          version: ${{ matrix.emacs-version }}
 
-      - name: paths
-        run: |
-          echo "$HOME/.cask/bin" >> $GITHUB_PATH
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+
+      - uses: emacs-eask/setup-eask@master
+        with:
+          version: 'snapshot'
+
       - name: Run a multi-line script
         run: |
           emacs --version
           make test
-          
-  # windows-build:
-  #   runs-on: windows-latest
-  #   strategy:
-  #     matrix:
-  #       emacs: [26.1, 26.2, 26.3, 27.1, 27.2, snapshot]
-
-  #   steps:
-  #     - uses: actions/checkout@v2
-
-  #     - uses: actions/setup-python@v2
-  #       with:
-  #         python-version: "3.6"
-  #         architecture: "x64"
-
-  #     - uses: jcs090218/setup-emacs-windows@master
-  #       with:
-  #         version: ${{ matrix.emacs }}
-
-  #     - uses: conao3/setup-cask@master
-  #       with:
-  #         version: 0.8.4
-
-  #     - name: Run a multi-line script
-  #       run: |
-  #         emacs --version
-  #         make test

--- a/.gitignore
+++ b/.gitignore
@@ -32,8 +32,8 @@ tramp
 # AUCTeX auto folder
 /auto/
 
-# cask packages
-.cask/
+# eask packages
+.eask/
 dist/
 
 # Flycheck

--- a/Cask
+++ b/Cask
@@ -1,4 +1,0 @@
-(source gnu)
-(source melpa)
-
-(package-file "typescript-mode.el")

--- a/Eask
+++ b/Eask
@@ -1,0 +1,14 @@
+(package "typescript-mode"
+         "0.4"
+         "Major mode for editing typescript")
+
+(package-file "typescript-mode.el")
+
+(files "*.el")
+
+(source "gnu")
+(source "melpa")
+
+(depends-on "emacs" "24.3")
+
+(setq network-security-level 'low)  ; see https://github.com/jcs090218/setup-emacs-windows/issues/156#issuecomment-932956432

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 EMACS ?= emacs
-CASK ?= cask
+EASK ?= eask
 ELS = \
   typescript-mode.el \
   typescript-mode-test-utilities.el \
@@ -11,10 +11,10 @@ ELCS = $(ELS:.el=.elc)
 clean:
 	rm -f $(ELCS)
 
-cask: clean
-	$(CASK) build
+eask: clean
+	$(EASK) build
 
-test: cask
+test: eask
 	+ $(EMACS) -Q -batch -L . -l typescript-mode-tests.el -f ert-run-tests-batch-and-exit
 
 # end


### PR DESCRIPTION
I have recently created a tool named [Eask](https://github.com/emacs-eask/eask). It's similar to Cask, but it has a better cross-platform capability. It tests your package/configuration in a much more consistent way.

This patch does the following:

1. Replace Cask with Eask
2. Add test for Emacs 28.1
3. `build.yml` now has only one job (merged unix + windows)
4. Fix test in `windows-latest`