### PR TITLE
feat(fontlock): fontify the variable and type in typeguard

### DIFF
--- a/typescript-mode-general-tests.el
+++ b/typescript-mode-general-tests.el
@@ -506,6 +506,19 @@ function foo<Z, Y, Z & Y, Z | Y | Z, Y<X<X, Y>>>()\n"
       "type Thing = number;"
     (should (eq (get-face-at "Thing") 'font-lock-type-face))))
 
+(ert-deftest font-lock/fontify-type-guard ()
+  "The type guard syntax
+
+    var is Type
+
+should be fontified as variable, keyword and type."
+  (test-with-fontified-buffer
+      "function test(var: unknown): var is RetType {\n}"
+    (should (eq (get-face-at 30) 'font-lock-variable-name-face))
+    (should (eq (get-face-at "is") 'font-lock-keyword-face))
+    (should (eq (get-face-at "RetType") 'font-lock-type-face))))
+
+
 (ert-deftest font-lock/type-names-level4 ()
   "Typenames should be highlighted in declarations"
 

--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -2094,7 +2094,7 @@ This performs fontification according to `typescript--class-styles'."
     ;; but need care to avoid affecting the // and */ comment markers.
     ("\\(?:^\\|[=([{,:;|&!]\\|\\_<return\\_>\\)\\(?:[ \t]\\)*\\(/\\)[^/*]"
      (1 (ignore
-	 (forward-char -1)
+     (forward-char -1)
          (when (or (not (memq (char-after (match-beginning 0)) '(?\s ?\t)))
                    ;; If the / is at the beginning of line, we have to check
                    ;; the end of the previous text.
@@ -2330,20 +2330,20 @@ the same column as the current line."
   (save-excursion
     (save-match-data
       (when (looking-at "\\s-*\\_<while\\_>")
-	(if (save-excursion
-	      (skip-chars-backward "[ \t\n]*}")
-	      (looking-at "[ \t\n]*}"))
-	    (save-excursion
-	      (backward-list) (forward-symbol -1) (looking-at "\\_<do\\_>"))
-	  (typescript--re-search-backward "\\_<do\\_>" (point-at-bol) t)
-	  (or (looking-at "\\_<do\\_>")
-	      (let ((saved-indent (current-indentation)))
-		(while (and (typescript--re-search-backward "^\\s-*\\_<" nil t)
-			    (/= (current-indentation) saved-indent)))
-		(and (looking-at "\\s-*\\_<do\\_>")
-		     (not (typescript--re-search-forward
-			   "\\_<while\\_>" (point-at-eol) t))
-		     (= (current-indentation) saved-indent)))))))))
+    (if (save-excursion
+          (skip-chars-backward "[ \t\n]*}")
+          (looking-at "[ \t\n]*}"))
+        (save-excursion
+          (backward-list) (forward-symbol -1) (looking-at "\\_<do\\_>"))
+      (typescript--re-search-backward "\\_<do\\_>" (point-at-bol) t)
+      (or (looking-at "\\_<do\\_>")
+          (let ((saved-indent (current-indentation)))
+        (while (and (typescript--re-search-backward "^\\s-*\\_<" nil t)
+                (/= (current-indentation) saved-indent)))
+        (and (looking-at "\\s-*\\_<do\\_>")
+             (not (typescript--re-search-forward
+               "\\_<while\\_>" (point-at-eol) t))
+             (= (current-indentation) saved-indent)))))))))
 
 
 (defun typescript--ctrl-statement-indentation ()
@@ -2952,9 +2952,9 @@ Key bindings:
         comment-start-skip "\\(//+\\|/\\*+\\)\\s *")
 
   (setq-local electric-indent-chars
-	      (append "{}():;," electric-indent-chars))
+          (append "{}():;," electric-indent-chars))
   (setq-local electric-layout-rules
-	      '((?\; . after) (?\{ . after) (?\} . before)))
+          '((?\; . after) (?\{ . after) (?\} . before)))
 
   (let ((c-buffer-is-cc-mode t))
     ;; FIXME: These are normally set by `c-basic-common-init'.  Should

--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -2013,10 +2013,13 @@ This performs fontification according to `typescript--class-styles'."
     ;; - private generic: SomeType<Foo>
     ;; - private genericArray: SomeType<Foo>[]
     ;; - function testFunc(): SomeType<> {
+    ;; - function testFunc(a): a is SomeType<> {
     ;; TODO: namespaced classes!
     ,(list
-      (concat ":\\s-\\(" typescript--type-name-re "\\)\\(<" typescript--type-name-re ">\\)?\\(\[\]\\)?\\([,;]\\)?\\s-*{?")
-      '(1 'font-lock-type-face))
+      (concat ":\\s-\\(?:\\s-*\\(" typescript--name-re "\\)\\s-*\\(is\\)\\s-*\\)?" "\\(" typescript--type-name-re "\\)\\(<" typescript--type-name-re ">\\)?\\(\[\]\\)?\\([,;]\\)?\\s-*{?")
+      '(1 'font-lock-variable-name-face nil t)
+      '(2 'font-lock-keyword-face nil t)
+      '(3 'font-lock-type-face))
 
     ;; type-casts
     ,(list


### PR DESCRIPTION
Fontify the variable and type in a type guard.

Before 

![image](https://user-images.githubusercontent.com/2664959/176715243-0373e19e-8cbd-49ab-a551-9b5737652d88.png)

After

![image](https://user-images.githubusercontent.com/2664959/176715291-b2164b53-e6c9-4171-b77b-c1fabfb21dd4.png)
