### PR TITLE
fix(fontlock): fontify parameters in multiline arglist

### DIFF
--- a/typescript-mode-general-tests.el
+++ b/typescript-mode-general-tests.el
@@ -593,6 +593,70 @@ should be fontified as variable, keyword and type."
     (should (eq (get-face-at "Namespaced") 'font-lock-type-face))
     (should (eq (get-face-at "ClassName") 'font-lock-type-face))))
 
+(ert-deftest font-lock/variables-in-declaration-multiline-with-types ()
+  "Variables should be highlighted in multiline declarations with types."
+  (test-with-fontified-buffer
+      "function test(
+var1: Type1,
+var2: Type2,
+): RetType {\n}"
+    (should (eq (get-face-at "var1") 'font-lock-variable-name-face))
+    (should (eq (get-face-at "var2") 'font-lock-variable-name-face))
+    (should (eq (get-face-at "Type1") 'font-lock-type-face))
+    (should (eq (get-face-at "Type2") 'font-lock-type-face))))
+
+(ert-deftest font-lock/variables-in-declaration-multiline-without-types ()
+  "Variables should be highlighted in multiline declarations without types."
+  (test-with-fontified-buffer
+      "function test(
+var1,
+var2,
+): RetType {\n}"
+    (should (eq (get-face-at "var1") 'font-lock-variable-name-face))
+    (should (eq (get-face-at "var2") 'font-lock-variable-name-face))))
+
+(ert-deftest font-lock/variables-in-declaration-multiline-no-hanging-paren ()
+  "Variables should be highlighted in multiline declarations with no hanging paren."
+  (test-with-fontified-buffer
+   "function test(
+var1,
+var2): RetType {\n}"
+   (should (eq (get-face-at "var1") 'font-lock-variable-name-face))
+   (should (eq (get-face-at "var2") 'font-lock-variable-name-face))))
+
+(ert-deftest font-lock/variables-in-declaration-multiline-ending-comma-no-hanging-paren ()
+  "Variables should be highlighted in multiline declarations with no hanging paren and trailing comma."
+  (test-with-fontified-buffer
+   "function test(
+var1,
+var2,): RetType {\n}"
+   (should (eq (get-face-at "var1") 'font-lock-variable-name-face))
+   (should (eq (get-face-at "var2") 'font-lock-variable-name-face))))
+
+(ert-deftest font-lock/variables-in-declaration-singleline-ending-comma-hanging-paren ()
+  "Variables should be highlighted in singleline declarations with hanging paren and trailing comma."
+  (test-with-fontified-buffer
+      "function test(var1,var2,
+): RetType {\n}"
+   (should (eq (get-face-at "var1") 'font-lock-variable-name-face))
+   (should (eq (get-face-at "var2") 'font-lock-variable-name-face))))
+
+(ert-deftest font-lock/variables-in-declaration-singleline-with-types ()
+  "Variables should be highlighted in singleline declarations with types."
+  (test-with-fontified-buffer
+      "function test(var1: Foo, var2: Bar,): RetType {\n}"
+   (should (eq (get-face-at "var1") 'font-lock-variable-name-face))
+   (should (eq (get-face-at "var2") 'font-lock-variable-name-face))
+   (should (eq (get-face-at "Foo") 'font-lock-type-face))
+   (should (eq (get-face-at "Bar") 'font-lock-type-face))))
+
+(ert-deftest font-lock/variables-in-declaration-singleline-ending-comma-no-hanging-paren ()
+  "Variables should be highlighted in singleline declarations with no hanging paren and trailing comma."
+  (test-with-fontified-buffer
+   "function test(var1,var2,): RetType {\n}"
+   (should (eq (get-face-at "var1") 'font-lock-variable-name-face))
+   (should (eq (get-face-at "var2") 'font-lock-variable-name-face))))
+
 (defun flyspell-predicate-test (search-for)
   "This function runs a test on
 `typescript--flyspell-mode-predicate'.  `SEARCH-FOR' is a string

--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -1859,23 +1859,12 @@ and searches for the next token to be highlighted."
     ,(list
       (concat
        "\\_<function\\_>\\(\\s-+" typescript--name-re "\\)?\\s-*\\(<.*>\\)?\\s-*(\\s-*"
-       typescript--name-start-re)
-      (list (concat "\\(" typescript--name-re "\\)\\(\\s-*).*\\)?")
-            '(backward-char)
-            '(end-of-line)
-            '(1 font-lock-variable-name-face)))
-
-    ;; continued formal parameter list
-    ,(list
-      (concat
-       "^\\s-*" typescript--name-re "\\s-*[,)]")
-      (list typescript--name-re
-            '(if (save-excursion (backward-char)
-                                 (typescript--inside-param-list-p))
-                 (forward-symbol -1)
-               (end-of-line))
-            '(end-of-line)
-            '(0 font-lock-variable-name-face))))
+       "\\(?:$\\|" typescript--name-start-re "\\)")
+      `(,(concat "\\(" typescript--name-re "\\)\\(?:\\s-*?\\([,:)]\\|$\\)\\)")
+        (prog1 (save-excursion (re-search-forward ")" nil t))
+          (backward-char))
+        nil
+        (1 font-lock-variable-name-face))))
   "Level three font lock for `typescript-mode'.")
 
 (defun typescript--flyspell-mode-predicate ()
@@ -2929,6 +2918,7 @@ Key bindings:
   (setq-local end-of-defun-function 'typescript-end-of-defun)
   (setq-local open-paren-in-column-0-is-defun-start nil)
   (setq-local font-lock-defaults (list typescript--font-lock-keywords))
+  (setq-local font-lock-multiline t)
   (setq-local syntax-propertize-function #'typescript-syntax-propertize)
   (setq-local parse-sexp-ignore-comments t)
   (setq-local parse-sexp-lookup-properties t)


### PR DESCRIPTION
Fix the anchored matcher to allow for multi-line arg list.  I will add tests if we decide to go forward with this change.

Before 
![image](https://user-images.githubusercontent.com/2664959/176743326-3cb8caf9-be40-4b75-8c44-a9a3ce743399.png)

after 

![image](https://user-images.githubusercontent.com/2664959/176743201-3aed4c51-63c2-470c-b2a2-1b68bd3db09e.png)

