### PR TITLE
fix(fontlock): fontify return type in a function type definition

### DIFF
--- a/typescript-mode-general-tests.el
+++ b/typescript-mode-general-tests.el
@@ -565,7 +565,11 @@ should be fontified as variable, keyword and type."
   (test-with-fontified-buffer
       "private genericArray3: SomeType<Foo[]>[];"
     (should (eq (get-face-at "SomeType") 'font-lock-type-face))
-    (should (eq (get-face-at "Foo") 'font-lock-type-face))))
+    (should (eq (get-face-at "Foo") 'font-lock-type-face)))
+
+  (test-with-fontified-buffer
+      "const f: () => SomeType = () => {}"
+    (should (eq (get-face-at "SomeType") 'font-lock-type-face))))
 
 (ert-deftest font-lock/type-names-level4-namespaces ()
   "Namespaced Typenames should be highlighted in declarations"

--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -2003,9 +2003,10 @@ This performs fontification according to `typescript--class-styles'."
     ;; - private genericArray: SomeType<Foo>[]
     ;; - function testFunc(): SomeType<> {
     ;; - function testFunc(a): a is SomeType<> {
+    ;; - () => SomeType
     ;; TODO: namespaced classes!
     ,(list
-      (concat ":\\s-\\(?:\\s-*\\(" typescript--name-re "\\)\\s-*\\(is\\)\\s-*\\)?" "\\(" typescript--type-name-re "\\)\\(<" typescript--type-name-re ">\\)?\\(\[\]\\)?\\([,;]\\)?\\s-*{?")
+      (concat "\\(?::\\|=>\\)\\s-\\(?:\\s-*\\(" typescript--name-re "\\)\\s-*\\(is\\)\\s-*\\)?" "\\(" typescript--type-name-re "\\)\\(<" typescript--type-name-re ">\\)?\\(\[\]\\)?\\([,;]\\)?\\s-*{?")
       '(1 'font-lock-variable-name-face nil t)
       '(2 'font-lock-keyword-face nil t)
       '(3 'font-lock-type-face))


### PR DESCRIPTION
Fontify as type the `SomeType` in the following:

```typescript
const f: () => SomeType = () => {};
```

Before

![image](https://user-images.githubusercontent.com/2664959/178101827-4355f33a-f6e5-4d3a-a94e-b51119cfa156.png)

After

![image](https://user-images.githubusercontent.com/2664959/178101819-ca286862-79e7-4491-8780-bf3ffad852bd.png)
