### PR TITLE
fix(fontlock): do not fontify function calls as keywords

### DIFF
--- a/typescript-mode-general-tests.el
+++ b/typescript-mode-general-tests.el
@@ -383,6 +383,17 @@ snake_cased_function(1, 2, 3)"
       (("endpoint" "data") . nil)
       (("<" ">" ",") . nil))))
 
+(ert-deftest font-lock/method-call-with-keyword-name ()
+  "If the name of the function/method is a keyword, it should still be highlighted as function."
+  (test-with-fontified-buffer
+      "const app = express();
+app.get()
+app.post()
+app.delete()"
+    (should (eq (get-face-at "get") 'font-lock-function-name-face))
+    (should (eq (get-face-at "post") 'font-lock-function-name-face))
+    (should (eq (get-face-at "delete") 'font-lock-function-name-face))))
+
 (ert-deftest font-lock/generics ()
   "Tests that type hints within generics are highlighted properly."
   (font-lock-test

--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -2020,7 +2020,7 @@ This performs fontification according to `typescript--class-styles'."
     ,@typescript--font-lock-keywords-3
 
     (,typescript--decorator-re (1 font-lock-function-name-face))
-    (,typescript--function-call-re (1 font-lock-function-name-face))
+    (,typescript--function-call-re (1 font-lock-function-name-face t))
     (,typescript--builtin-re (1 font-lock-type-face))
 
     ;; arrow function


### PR DESCRIPTION
If a method/function is named same as keyword or built-in, it should
still be fontified as method/function call.

Before

![image](https://user-images.githubusercontent.com/2664959/178108102-3e208696-753e-4bac-9f3c-c0621c923e28.png)

After

![image](https://user-images.githubusercontent.com/2664959/178108076-7ecc8a6c-b90f-4926-a1de-2ba22df4ac8c.png)

Fixes #103