### PR TITLE
fix(fontlock): do not fontify builtins in object/interface key context

### DIFF
--- a/typescript-mode-general-tests.el
+++ b/typescript-mode-general-tests.el
@@ -287,6 +287,19 @@ a severity set to WARNING, no rule name."
  " * @param {Something} bar A parameter. References [[moo]] and [[foo]].
  * @param second May hold ``x`` or ``y``.")
 
+(ert-deftest font-lock/interface-builtin-key-context-unfontify ()
+  "Builtins should not be fontified when they are in object or
+interface key context."
+  (test-with-fontified-buffer
+      "interface Foo { type: number; unknown: string; foo: boolean }"
+    (should (eq (get-face-at "type") 'default))
+    (should (eq (get-face-at "unknown") 'default)))
+
+  (test-with-fontified-buffer
+      "const x = { type: 4; unknown: 'bar'; foo: true }"
+    (should (eq (get-face-at "type") 'default))
+    (should (eq (get-face-at "unknown") 'default))))
+
 (ert-deftest font-lock/documentation-in-documentation-comments ()
   "Documentation in documentation comments should be fontified as
 documentation."

--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -1737,6 +1737,14 @@ and searches for the next token to be highlighted."
   `(
     ,@typescript--font-lock-keywords-2
 
+    ;; Remove the fontification of keywords and built-ins when they
+    ;; are keys in an interface, object or class.
+    (,(rx "{")
+     (,(concat "\\(" typescript--keyword-re "\\):")
+      (save-excursion (ignore-errors (up-list)) (point))
+      nil
+      (1 'default t t)))
+
     (typescript--jsdoc-param-matcher (1 'typescript-jsdoc-tag t t)
                                      (2 'typescript-jsdoc-type t t)
                                      (3 'typescript-jsdoc-value t t))


### PR DESCRIPTION
Before

![image](https://user-images.githubusercontent.com/2664959/178109257-e627dafa-c0b6-4fb0-98c9-2442246fcb6e.png)

After

![image](https://user-images.githubusercontent.com/2664959/178109243-da106593-cb0d-4f23-b5c8-18aa425a0502.png)
