### PR TITLE
fix(fontlock): only re-fontify method calls with reserved words

### DIFF
--- a/typescript-mode-general-tests.el
+++ b/typescript-mode-general-tests.el
@@ -397,15 +397,19 @@ snake_cased_function(1, 2, 3)"
       (("<" ">" ",") . nil))))
 
 (ert-deftest font-lock/method-call-with-keyword-name ()
-  "If the name of the function/method is a keyword, it should still be highlighted as function."
+  "If the name of the method is a keyword, it should still be highlighted as function."
   (test-with-fontified-buffer
       "const app = express();
 app.get()
 app.post()
-app.delete()"
+app.delete()
+if (true) {}
+// for (abc) {}"
     (should (eq (get-face-at "get") 'font-lock-function-name-face))
     (should (eq (get-face-at "post") 'font-lock-function-name-face))
-    (should (eq (get-face-at "delete") 'font-lock-function-name-face))))
+    (should (eq (get-face-at "delete") 'font-lock-function-name-face))
+    (should (eq (get-face-at "if") 'font-lock-keyword-face))
+    (should (eq (get-face-at "for") 'font-lock-comment-face))))
 
 (ert-deftest font-lock/generics ()
   "Tests that type hints within generics are highlighted properly."

--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -2137,7 +2137,9 @@ This performs fontification according to `typescript--class-styles'."
     ,@typescript--font-lock-keywords-3
 
     (,typescript--decorator-re (1 font-lock-function-name-face))
-    (,typescript--function-call-re (1 font-lock-function-name-face t))
+    (,typescript--function-call-re (1 font-lock-function-name-face))
+    (,(concat "\\(?:\\.\\s-*\\)" typescript--function-call-re)
+     (1 font-lock-function-name-face t))
     (,typescript--builtin-re (1 font-lock-type-face))
 
     ;; arrow function


### PR DESCRIPTION
Functions can not be called after a reserved word such as `if` or
`delete`, however methods can.  Only re-apply fontification on
methods.

Fixes #174 