### PR TITLE
feat(fontlock): fontify ${} expressions inside backticks

### DIFF
--- a/typescript-mode-general-tests.el
+++ b/typescript-mode-general-tests.el
@@ -823,6 +823,31 @@ bbb: Bar,
     (should (eq (get-face-at "Foo") 'font-lock-type-face))
     (should (eq (get-face-at "Bar") 'font-lock-type-face))))
 
+(ert-deftest font-lock/backticks--expr-fontification--with-variable ()
+  (test-with-fontified-buffer
+      "const x = `hello ${world}`"
+    (should (eq (get-face-at "${") 'font-lock-keyword-face))
+    (should (eq (get-face-at "world") 'default))
+    (should (eq (get-face-at "}") 'font-lock-keyword-face))))
+
+(ert-deftest font-lock/backticks--expr-fontification--not-in-regular-string ()
+  (test-with-fontified-buffer
+      "const x = 'hello ${world}'"
+    (should (eq (get-face-at "${") 'font-lock-string-face))
+    (should (eq (get-face-at "world") 'font-lock-string-face))
+    (should (eq (get-face-at "}") 'font-lock-string-face))))
+
+(ert-deftest font-lock/backticks--expr-fontification--with-funcall ()
+  "For now function calls or any other expressions are fontified as
+if a simple variable token in its entirety.  When/if this is
+implemented better, this test should be adjusted to capture the
+new functionality."
+  (test-with-fontified-buffer
+      "const x = `hello ${parseInt(foobar)}`"
+    (should (eq (get-face-at "${") 'font-lock-keyword-face))
+    (should (eq (get-face-at "parseInt(foobar)") 'default))
+    (should (eq (get-face-at "}") 'font-lock-keyword-face))))
+
 (ert-deftest font-lock/funargs--method--multiline--with-type ()
   (test-with-fontified-buffer
       "class Foo { foo(

--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -2115,6 +2115,20 @@ This performs fontification according to `typescript--class-styles'."
         return t
         else do (goto-char orig-end)))
 
+(defun typescript--match-subst-in-quotes (limit)
+  "Match dollar substitutions inside backticks."
+  (catch 'done
+    (while (re-search-forward
+            ;; `rx' is cool, mkay.
+            (rx (or line-start (not (any "\\")))
+                (group "${")
+                (group (+? nonl))
+                (group "}"))
+            limit t)
+      (let ((string-delim (nth 3 (syntax-ppss))))
+        (when (and string-delim (= string-delim 96))
+          (throw 'done (point)))))))
+
 (defconst typescript--font-lock-keywords-4
   `(
     ;; highlights that override previous levels
@@ -2170,7 +2184,12 @@ This performs fontification according to `typescript--class-styles'."
 
     ;; arrow function
     ("\\(=>\\)"
-     (1 font-lock-keyword-face)))
+     (1 font-lock-keyword-face))
+
+    (typescript--match-subst-in-quotes
+     (1 'font-lock-keyword-face t)
+     (2 'default t)
+     (3 'font-lock-keyword-face t)))
   "Level four font lock for `typescript-mode'.")
 
 (defconst typescript--font-lock-keywords


### PR DESCRIPTION
Addresses #48 until better parser support is implemented.

This is an 80/20 approach so complex expressions inside the `${}` are fontified as if a simple variable token.  It probably can be improved in further iterations.

![image](https://user-images.githubusercontent.com/2664959/183421469-509e6a1d-374e-4a5e-9c5d-878543a44c9e.png)

![image](https://user-images.githubusercontent.com/2664959/183421399-9bd7a43e-e87f-4ba1-8686-db5362fa70fd.png)
