### PR TITLE
Update note after ts-mode rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ than keeping this old version around.
 
 ## Good news!
 Emacs 29 will ship with tree-sitter support, and it will actually have in-tree
-support for TypeScript!  So now you can just use the provided `ts-mode` and get
+support for TypeScript!  So now you can just use the provided `typescript-ts-mode` and get
 the fresh tree-sitter powered functionalities for free.  Yes, that means both
 tsx and regular types will actually work.  Development will continue in emacs
 core, rather than this repo.  We hope you'll like the new experience.


### PR DESCRIPTION
Hello, 

It seems `ts-mode` has been renamed in the core to `typescript-ts-mode` as can be seen in [this commit](https://git.savannah.gnu.org/cgit/emacs.git/commit/?id=7fc0eae28f03601e25e2a60030ae2dc59085c6d2) and as was discussed [here](https://lists.gnu.org/archive/html/emacs-devel/2022-11/msg01607.html).

Best regards
alternateved