### PR TITLE
Add .tsx to auto-mode-alist

### DIFF
--- a/typescript-mode-general-tests.el
+++ b/typescript-mode-general-tests.el
@@ -18,6 +18,14 @@
   (indent-region (point-min) (point-max) nil)
   (untabify (point-min) (point-max)))
 
+(ert-deftest auto-mode-alist-ts ()
+  (find-file (make-temp-file load-file-name nil ".ts"))
+  (should (string-equal "typescript-mode" major-mode)))
+
+(ert-deftest auto-mode-alist-tsx ()
+  (find-file (make-temp-file load-file-name nil ".tsx"))
+  (should (string-equal "typescript-mode" major-mode)))
+
 (ert-deftest indentation-reference-document-is-reflowed-correctly ()
   (with-temp-buffer
     (insert-file-contents "test-files/indentation-reference-document.ts")

--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -3119,7 +3119,7 @@ Key bindings:
      (folding-add-to-marks-list 'typescript-mode "// {{{" "// }}}" )))
 
 ;;;###autoload
-(add-to-list 'auto-mode-alist '("\\.ts\\'" . typescript-mode))
+(add-to-list 'auto-mode-alist '("\\.tsx?\\'" . typescript-mode))
 
 (provide 'typescript-mode)
 


### PR DESCRIPTION
Add out-of-the-box support for using typescript-mode on *.tsx files. Avoids repetitive manual configuration for end users.