### PR TITLE
Misc minor issues (courtesy of Stefan Monnier)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,7 @@ $RECYCLE.BIN/
 *.lnk
 
 # End of https://www.gitignore.io/api/emacs,windows,linux
+
+# ELPA-generated files.
+/typescript-mode-autoloads.el
+/typescript-mode-pkg.el

--- a/typescript-mode-general-tests.el
+++ b/typescript-mode-general-tests.el
@@ -391,15 +391,15 @@ private async innerExecuteAsync<TResponse extends Response, TValue>(endpoint: st
 innerExecuteAsync(x: string, y: boolean, z: number, j?: any): Promise<FResponse> {\n
 console.log(this.methodCall());\n
 snake_cased_function(1, 2, 3)"
-    '(("@decorator" . font-lock-function-name-face)
+    '(("@decorator" . font-lock-function-call-face)
       ("Foo" . font-lock-type-face)
       ("private" . typescript-access-modifier-face)
       ("innerExecuteAsync" . font-lock-function-name-face)
       (("TResponse" "FResponse" "Response" "TValue") . font-lock-type-face)
       ("console" . font-lock-type-face)
       ("this" . typescript-this-face)
-      ("methodCall" . font-lock-function-name-face)
-      ("snake_cased_function" . font-lock-function-name-face)
+      ("methodCall" . font-lock-function-call-face)
+      ("snake_cased_function" . font-lock-function-call-face)
       (("string" "boolean" "number" "any") . typescript-primitive-face)
       (("endpoint" "data") . font-lock-variable-name-face)
       (("<" ">" ",") . nil))))
@@ -413,9 +413,9 @@ app.post()
 app.delete()
 if (true) {}
 // for (abc) {}"
-    (should (eq (get-face-at "get") 'font-lock-function-name-face))
-    (should (eq (get-face-at "post") 'font-lock-function-name-face))
-    (should (eq (get-face-at "delete") 'font-lock-function-name-face))
+    (should (eq (get-face-at "get") 'font-lock-function-call-face))
+    (should (eq (get-face-at "post") 'font-lock-function-call-face))
+    (should (eq (get-face-at "delete") 'font-lock-function-call-face))
     (should (eq (get-face-at "if") 'font-lock-keyword-face))
     (should (eq (get-face-at "for") 'font-lock-comment-face))))
 
@@ -861,7 +861,8 @@ bbb: Bar,
 
 (ert-deftest font-lock/funargs--method--single-line--with-type ()
   (test-with-fontified-buffer
-      "class Foo { foo(aaa: Foo,bbb: Bar,): void {}"
+      "class Foo { foom(aaa: Foo,bbb: Bar,): void {}"
+    (should (eq (get-face-at "foom") 'font-lock-function-name-face))
     (should (eq (get-face-at "aaa") 'font-lock-variable-name-face))
     (should (eq (get-face-at "bbb") 'font-lock-variable-name-face))
     (should (eq (get-face-at "Foo") 'font-lock-type-face))

--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -1,9 +1,9 @@
-;;; typescript-mode.el --- Major mode for editing typescript
+;;; typescript-mode.el --- Major mode for editing typescript  -*- lexical-binding: t -*-
 
 ;; -----------------------------------------------------------------------------------
 ;;     TypeScript support for Emacs
 ;;     Unmodified original sourve available at http://www.karllandstrom.se/downloads/emacs/javascript.el
-;;     Copyright (c) 2008 Free Software Foundation
+;;     Copyright (c) 2008-2025 Free Software Foundation
 ;;     Portions Copyright (C) Microsoft Open Technologies, Inc. All rights reserved.
 ;;
 ;;     This program is free software: you can redistribute it and/or modify
@@ -312,13 +312,13 @@ Match group 1 is MUMBLE.")
 
 (defconst typescript--font-lock-keywords-2
   (append typescript--font-lock-keywords-1
-          (list (cons typescript--constant-re font-lock-constant-face)
-                (cons typescript--basic-type-re font-lock-type-face)
-                (list typescript--keyword-re 1 font-lock-keyword-face)
-                (list "\\_<for\\_>"
-                      "\\s-+\\(each\\)\\_>" nil nil
-                      (list 1 'font-lock-keyword-face))
-                (cons "\\_<yield\\(\\*\\|\\_>\\)" 'font-lock-keyword-face)))
+          `((,typescript--constant-re (0 'font-lock-constant-face))
+            (,typescript--basic-type-re (0 'font-lock-type-face))
+            (,typescript--keyword-re (1 'font-lock-keyword-face))
+            ("\\_<for\\_>"
+             ("\\s-+\\(each\\)\\_>" nil nil
+              (1 'font-lock-keyword-face)))
+            ("\\_<yield\\(\\*\\|\\_>\\)" (0 'font-lock-keyword-face))))
   "Level two font lock keywords for `typescript-mode'.")
 
 ;; typescript--pitem is the basic building block of the lexical
@@ -935,15 +935,16 @@ point at BOB."
 This function invokes `re-search-forward', but treats the buffer
 as if strings and comments have been removed."
   (let ((saved-point (point))
-        (search-expr
+        (search-fun
          (cond ((null count)
-                '(typescript--re-search-forward-inner regexp bound 1))
+                (lambda () (typescript--re-search-forward-inner regexp bound 1)))
                ((< count 0)
-                '(typescript--re-search-backward-inner regexp bound (- count)))
+                (lambda () (typescript--re-search-backward-inner regexp bound (- count))))
                ((> count 0)
-                '(typescript--re-search-forward-inner regexp bound count)))))
+                (lambda () (typescript--re-search-forward-inner regexp bound count)))
+               (t #'ignore))))
     (condition-case err
-        (eval search-expr)
+        (funcall search-fun)
       (search-failed
        (goto-char saved-point)
        (unless noerror
@@ -990,15 +991,16 @@ If the point is in the last line, searching back for \"\\n\" will
 skip over the line with \"let b\". The newline found will be the
 one at the end of the line with \"let a\"."
   (let ((saved-point (point))
-        (search-expr
+        (search-fun
          (cond ((null count)
-                `(typescript--re-search-backward-inner ,regexp ,bound 1))
+                (lambda () (typescript--re-search-backward-inner regexp bound 1)))
                ((< count 0)
-                `(typescript--re-search-forward-inner ,regexp ,bound (- ,count)))
+                (lambda () (typescript--re-search-forward-inner regexp bound (- count))))
                ((> count 0)
-                `(typescript--re-search-backward-inner ,regexp ,bound ,count)))))
+                (lambda () (typescript--re-search-backward-inner regexp bound count)))
+               (t #'ignore))))
     (condition-case err
-        (eval search-expr)
+        (funcall search-fun)
       (search-failed
        (goto-char saved-point)
        (unless noerror
@@ -1839,35 +1841,35 @@ and searches for the next token to be highlighted."
      (0 'typescript-jsdoc-value t))
 
     (typescript--tslint-flag-matcher
-     (1 font-lock-preprocessor-face t))
+     (1 'font-lock-preprocessor-face t))
 
     ("\\.\\(prototype\\)\\_>"
-     (1 font-lock-constant-face))
+     (1 'font-lock-constant-face))
 
     (,(rx symbol-start "class" (+ space) (group (+ (or (syntax word) (syntax symbol)))))
-     (1 font-lock-type-face))
+     (1 'font-lock-type-face))
 
     (,(rx symbol-start "extends" (+ space) (group (+ (or (syntax word) (syntax symbol)))))
-     (1 font-lock-type-face))
+     (1 'font-lock-type-face))
 
     (,(rx symbol-start "implements" (+ space))
-     (,(rx symbol-start (+ (syntax word))) nil nil (0 font-lock-type-face)))
+     (,(rx symbol-start (+ (syntax word))) nil nil (0 'font-lock-type-face)))
 
     (,(rx symbol-start "interface" (+ space) (group (+ (or (syntax word) (syntax symbol)))))
-     (1 font-lock-type-face))
+     (1 'font-lock-type-face))
 
     (,(rx symbol-start "type" (+ space) (group (+ (or (syntax word) (syntax symbol)))))
-     (1 font-lock-type-face))
+     (1 'font-lock-type-face))
 
     (,(rx symbol-start "enum" (+ space) (group (+ (or (syntax word) (syntax symbol)))))
-     (1 font-lock-type-face))
+     (1 'font-lock-type-face))
 
     ;; Highlights class being declared, in parts
     (typescript--class-decl-matcher
      ,(concat "\\(" typescript--name-re "\\)\\(?:\\.\\|.*$\\)")
      (goto-char (match-beginning 1))
      nil
-     (1 font-lock-type-face))
+     (1 'font-lock-type-face))
 
     ;; Highlights parent class, in parts, if available
     (typescript--class-decl-matcher
@@ -1884,11 +1886,11 @@ and searches for the next token to be highlighted."
        (save-excursion
          (goto-char typescript--tmp-location)
          (delete-char 1)))
-     (1 font-lock-type-face))
+     (1 'font-lock-type-face))
 
     ;; Highlights parent class
     (typescript--class-decl-matcher
-     (2 font-lock-type-face nil t))
+     (2 'font-lock-type-face nil t))
 
     ;; Dojo needs its own matcher to override the string highlighting
     (,(typescript--make-framework-matcher
@@ -1896,8 +1898,8 @@ and searches for the next token to be highlighted."
        "^\\s-*dojo\\.declare\\s-*(\""
        "\\(" typescript--dotted-name-re "\\)"
        "\\(?:\"\\s-*,\\s-*\\(" typescript--dotted-name-re "\\)\\)?")
-     (1 font-lock-type-face t)
-     (2 font-lock-type-face nil t))
+     (1 'font-lock-type-face t)
+     (2 'font-lock-type-face nil t))
 
     ;; Match Dojo base classes. Of course Mojo has to be different
     ;; from everything else under the sun...
@@ -1909,7 +1911,7 @@ and searches for the next token to be highlighted."
               "\\(?:\\].*$\\)?")
      (backward-char)
      (end-of-line)
-     (1 font-lock-type-face))
+     (1 'font-lock-type-face))
 
     ;; continued Dojo base-class list
     (,(typescript--make-framework-matcher
@@ -1922,7 +1924,7 @@ and searches for the next token to be highlighted."
          (forward-symbol -1)
        (end-of-line))
      (end-of-line)
-     (1 font-lock-type-face))
+     (1 'font-lock-type-face))
 
     ;; variable declarations
     ,(list
@@ -1930,14 +1932,12 @@ and searches for the next token to be highlighted."
       (list #'typescript--variable-decl-matcher nil nil nil))
 
     ;; class instantiation
-    ,(list
-      (concat "\\_<new\\_>\\s-+\\(" typescript--dotted-name-re "\\)")
-      (list 1 'font-lock-type-face))
+    (,(concat "\\_<new\\_>\\s-+\\(" typescript--dotted-name-re "\\)")
+     (1 'font-lock-type-face))
 
     ;; instanceof
-    ,(list
-      (concat "\\_<instanceof\\_>\\s-+\\(" typescript--dotted-name-re "\\)")
-      (list 1 'font-lock-type-face))
+    (,(concat "\\_<instanceof\\_>\\s-+\\(" typescript--dotted-name-re "\\)")
+     (1 'font-lock-type-face))
 
     ;; formal parameters in "function" function call
     ;; function helloWorld(a: number, b: Promise<number>): void { }
@@ -2162,7 +2162,7 @@ This performs fontification according to `typescript--class-styles'."
     ;; - () => SomeType
     ;; TODO: namespaced classes!
     ,(list
-      (concat "\\(?::\\|=>\\)\\s-\\(?:\\s-*\\(" typescript--name-re "\\)\\s-*\\(is\\)\\s-*\\)?" "\\(" typescript--type-name-re "\\)\\(<" typescript--type-name-re ">\\)?\\(\[\]\\)?\\([,;]\\)?\\s-*{?")
+      (concat "\\(?::\\|=>\\)\\s-\\(?:\\s-*\\(" typescript--name-re "\\)\\s-*\\(is\\)\\s-*\\)?" "\\(" typescript--type-name-re "\\)\\(<" typescript--type-name-re ">\\)?\\(\\[\\]\\)?\\([,;]\\)?\\s-*{?")
       '(1 'font-lock-variable-name-face nil t)
       '(2 'font-lock-keyword-face nil t)
       '(3 'font-lock-type-face))
@@ -2179,12 +2179,12 @@ This performs fontification according to `typescript--class-styles'."
     (,typescript--decorator-re (1 'font-lock-function-call-face))
     (,typescript--function-call-re (1 (typescript--function-face)))
     (,(concat "\\(?:\\.\\s-*\\)" typescript--function-call-re)
-     (1 font-lock-function-call-face t))
-    (,typescript--builtin-re (1 font-lock-type-face))
+     (1 'font-lock-function-call-face t))
+    (,typescript--builtin-re (1 'font-lock-type-face))
 
     ;; arrow function
     ("\\(=>\\)"
-     (1 font-lock-keyword-face))
+     (1 'font-lock-keyword-face))
 
     (typescript--match-subst-in-quotes
      (1 'font-lock-keyword-face t)

--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -2176,10 +2176,10 @@ This performs fontification according to `typescript--class-styles'."
     ;;
     ,@typescript--font-lock-keywords-3
 
-    (,typescript--decorator-re (1 font-lock-function-name-face))
-    (,typescript--function-call-re (1 font-lock-function-name-face))
+    (,typescript--decorator-re (1 'font-lock-function-call-face))
+    (,typescript--function-call-re (1 (typescript--function-face)))
     (,(concat "\\(?:\\.\\s-*\\)" typescript--function-call-re)
-     (1 font-lock-function-name-face t))
+     (1 font-lock-function-call-face t))
     (,typescript--builtin-re (1 font-lock-type-face))
 
     ;; arrow function
@@ -2191,6 +2191,22 @@ This performs fontification according to `typescript--class-styles'."
      (2 'default t)
      (3 'font-lock-keyword-face t)))
   "Level four font lock for `typescript-mode'.")
+
+(defun typescript--function-face ()
+  "Return the face to use depending if it's a definition or a call.
+Point is assumed to be right after the open paren."
+  (save-excursion
+    (forward-char -1)
+    (if (condition-case nil
+            (progn
+              (forward-sexp 1)
+              (forward-comment (point-max))
+              (memq (char-after) '(?: ?\{)))
+          (scan-error nil))
+        ;; Looks like a declaration/definition.
+        'font-lock-function-name-face
+      ;; Probably just a call.
+      'font-lock-function-call-face)))
 
 (defconst typescript--font-lock-keywords
   '(typescript--font-lock-keywords-4 typescript--font-lock-keywords-1


### PR DESCRIPTION
* typescript-mode.el: Activate `lexical-binding`.
* (typescript--font-lock-keywords-2): Use backquote.  Quote face names so as not to rely on obsolete `font-lock-*-face` variables.
 * (typescript--re-search-forward, typescript--re-search-backward): Use `funcall` instead of `eval` to save kittens and be compatible with `lexical-binding`.
* (typescript--font-lock-keywords-3): Quote face names as above.
* (typescript--font-lock-keywords-4): Fix "\[\]" to "\\[\\]".
* Use `font-lock-function-call-face` for function calls.
* Quote face names as above.